### PR TITLE
Run lint and infra test in parallel

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -31,7 +31,6 @@ jobs:
 
   test-infrastructure:
     name: Test Against Infrastructure
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Remove `needs: lint` dependency so both jobs start immediately
- Should reduce total CI time by running them concurrently

Part of #48

## Test plan
- [ ] Verify both jobs start at the same time
- [ ] Compare total run time vs previous runs