### PR TITLE
Add cache_valid_time to apt tasks

### DIFF
--- a/ansible/roles/jellyfin_backup/tasks/main.yml
+++ b/ansible/roles/jellyfin_backup/tasks/main.yml
@@ -6,6 +6,7 @@
     name: rclone
     state: present
     update_cache: yes
+    cache_valid_time: 3600
 
 - name: Create rclone config directory
   ansible.builtin.file:

--- a/ansible/roles/tailscale/tasks/install.yml
+++ b/ansible/roles/tailscale/tasks/install.yml
@@ -25,6 +25,7 @@
 - name: Update apt cache after adding Tailscale repo
   apt:
     update_cache: yes
+    cache_valid_time: 3600
   changed_when: false
 
 - name: Ensure required packages are installed


### PR DESCRIPTION
## Summary
Skip apt cache update if cache is less than 1 hour old.

Fixed roles:
- tailscale
- jellyfin_backup

(nut already had it)

Part of #48

## Test plan
- [x] CI passes
- [x] Verify faster runs when apt cache is fresh