### PR TITLE
Add pip caching to CI workflow

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -20,10 +20,11 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: 'ansible/requirements.txt'
 
       - name: Install Ansible and ansible-lint
         run: |
-          pip install ansible ansible-lint
+          pip install -r ansible/requirements.txt
 
       - name: Run ansible-lint
         run: |
@@ -42,10 +43,11 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: 'ansible/requirements.txt'
 
       - name: Install Ansible
         run: |
-          pip install ansible
+          pip install -r ansible/requirements.txt
 
       - name: Setup Tailscale
         uses: tailscale/github-action@v4

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,0 +1,2 @@
+ansible
+ansible-lint


### PR DESCRIPTION
## Summary
Cache pip packages between runs using setup-python's built-in cache.

Saves ~20-30s per job on cache hits.

Part of #48

## Test plan
- [x] First run populates cache
- [x] Second run shows cache hit and faster install