### PR TITLE
Fix Ansible deprecation warnings in Tailscale role

### DIFF
--- a/ansible/roles/tailscale/tasks/install.yml
+++ b/ansible/roles/tailscale/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
 - name: Detect OS distribution
   set_fact:
-    tailscale_distro: "{{ 'ubuntu' if ansible_distribution == 'Ubuntu' else 'debian' }}"
-    tailscale_codename: "{{ ansible_distribution_release }}"
+    tailscale_distro: "{{ 'ubuntu' if ansible_facts['distribution'] == 'Ubuntu' else 'debian' }}"
+    tailscale_codename: "{{ ansible_facts['distribution_release'] }}"
 
 - name: Ensure Tailscale GPG key is properly formatted
   shell: |


### PR DESCRIPTION
## Summary
Use `ansible_facts['distribution']` instead of top-level `ansible_distribution`.

Prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` defaults to False.

Fixes #39

## Test plan
- [ ] CI passes
- [ ] No deprecation warnings in output