### PR TITLE
Add explicit file permissions to config tasks

### DIFF
--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -14,7 +14,6 @@ skip_list:
   - var-naming[no-role-prefix]  # TODO: Rename variables with role prefix
   - no-changed-when  # We have some command tasks that are intentionally not idempotent checks
   - risky-shell-pipe  # We use pipes in shell commands carefully
-  - risky-file-permissions  # TODO: Add explicit permissions
   - command-instead-of-module  # We use curl for GPG key to avoid issues
   - internal-error  # Expected - vault files need password
 

--- a/ansible/roles/nut/tasks/client.yml
+++ b/ansible/roles/nut/tasks/client.yml
@@ -27,6 +27,7 @@
     path: /etc/nut/nut.conf
     regexp: '^MODE='
     line: 'MODE=netclient'
+    mode: '0640'
     create: true
 
 - name: Configure upsmon.conf for full network monitoring

--- a/ansible/roles/nut/tasks/server.yml
+++ b/ansible/roles/nut/tasks/server.yml
@@ -2,6 +2,7 @@
 - name: Configure ups.conf
   copy:
     dest: /etc/nut/ups.conf
+    mode: '0640'
     content: |
       [{{ ups_name }}]
       driver = {{ ups_driver }}
@@ -30,6 +31,7 @@
 - name: Configure upsd.conf to listen on all interfaces
   copy:
     dest: /etc/nut/upsd.conf
+    mode: '0640'
     content: |
       LISTEN 0.0.0.0
   notify: Restart NUT services
@@ -37,6 +39,7 @@
 - name: Configure nut.conf to standalone
   copy:
     dest: /etc/nut/nut.conf
+    mode: '0640'
     content: "MODE=standalone\n"
   notify: Restart NUT services
 

--- a/ansible/roles/proxmox/tasks/subscription-nag.yml
+++ b/ansible/roles/proxmox/tasks/subscription-nag.yml
@@ -12,6 +12,7 @@
     src: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
     dest: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js.bak
     remote_src: true
+    mode: '0644'
     force: false
   when: proxmoxlib_file.stat.exists
 


### PR DESCRIPTION
## Summary
Add explicit `mode:` to file/copy tasks to satisfy `risky-file-permissions` rule.

Permissions verified against live systems and documentation:
- NUT configs: 0640 (per [NUT Security docs](https://networkupstools.org/docs/user-manual.chunked/NUT_Security.html))
- upsmon.conf: 0600 (contains passwords)
- proxmoxlib.js backup: 0644 (standard web asset permissions)

Removes `risky-file-permissions` from ansible-lint skip list.

Part of #20

## Test plan
- [ ] CI passes with rule enabled