### PR TITLE
Fix ansible-lint no-changed-when violations

### DIFF
--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -12,7 +12,6 @@ exclude_paths:
 skip_list:
   - fqcn[action-core]  # TODO: Convert to FQCN in future
   - var-naming[no-role-prefix]  # TODO: Rename variables with role prefix
-  - no-changed-when  # We have some command tasks that are intentionally not idempotent checks
   - risky-shell-pipe  # We use pipes in shell commands carefully
   - command-instead-of-module  # We use curl for GPG key to avoid issues
   - internal-error  # Expected - vault files need password

--- a/ansible/roles/netdata/handlers/main.yml
+++ b/ansible/roles/netdata/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: Reload netdata claiming
   command: /usr/sbin/netdatacli reload-claiming-state
   failed_when: false  # May fail if service not fully started yet
+  changed_when: true
 
 - name: Clean up netdata-repo package
   file:

--- a/ansible/roles/proxmox/tasks/subscription-nag.yml
+++ b/ansible/roles/proxmox/tasks/subscription-nag.yml
@@ -30,6 +30,7 @@
     - already_patched is not skipped
     - already_patched.rc != 0
   register: patch_result
+  changed_when: patch_result.rc == 0
   notify: Restart pveproxy
 
 - name: Create persistence script directory

--- a/ansible/roles/tailscale/tasks/auth.yml
+++ b/ansible/roles/tailscale/tasks/auth.yml
@@ -34,6 +34,7 @@
     {% if tailscale_enable_ssh | default(true) %}--ssh{% endif %}
   when: tailscale_status.rc != 0
   register: auth_status
+  changed_when: auth_status.rc == 0
   no_log: true
 
 - name: Update Tailscale tags on already-authenticated devices
@@ -55,3 +56,4 @@
     - tailscale_status.rc == 0
     - tailscale_tags is not defined
   register: ssh_result
+  changed_when: ssh_result.rc == 0

--- a/ansible/roles/tailscale/tasks/certs.yml
+++ b/ansible/roles/tailscale/tasks/certs.yml
@@ -33,6 +33,7 @@
   command: tailscale cert --cert-file /tmp/pveproxy-ssl.pem --key-file /tmp/pveproxy-ssl.key {{ tailscale_hostname.stdout }}
   when: needs_renewal
   register: cert_result
+  changed_when: cert_result.rc == 0
 
 - name: Copy certificate to Proxmox location
   shell: |
@@ -40,6 +41,7 @@
     chown {{ tailscale_cert_owner }}:{{ tailscale_cert_group }} {{ tailscale_cert_path }}
     chmod {{ tailscale_cert_mode }} {{ tailscale_cert_path }}
   when: needs_renewal
+  changed_when: true
 
 - name: Copy key to Proxmox location
   shell: |
@@ -47,6 +49,7 @@
     chown {{ tailscale_cert_owner }}:{{ tailscale_cert_group }} {{ tailscale_key_path }}
     chmod {{ tailscale_cert_mode }} {{ tailscale_key_path }}
   when: needs_renewal
+  changed_when: true
 
 - name: Clean up temp certificate files
   file:


### PR DESCRIPTION
## Summary
- Add explicit `changed_when` to command/shell tasks in netdata, proxmox, and tailscale roles
- Remove `no-changed-when` from skip_list as all violations are now fixed

## Test plan
- [x] Verify ansible-lint passes in CI
- [x] Run `--check --diff` on a Proxmox host to verify no unexpected changes

Fixes part of #20