### PR TITLE
Convert to fully qualified collection names (FQCN)

### DIFF
--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -6,11 +6,10 @@
 exclude_paths:
   - archive/
   - .ansible/
-  - '*.retry'
+  - "*.retry"
 
 # Skip specific rules for now (fix in future PR)
 skip_list:
-  - fqcn[action-core]  # Fixed in PR #59
   - var-naming[no-role-prefix]  # TODO: Rename variables with role prefix
   - command-instead-of-module  # We use curl for GPG key to avoid issues
   - internal-error  # Expected - vault files need password

--- a/ansible/group_vars/proxmox.yml
+++ b/ansible/group_vars/proxmox.yml
@@ -22,7 +22,7 @@ ups_admin_user: admin
 ups_monitor_user: monuser
 
 # Client configuration (server IP is auto-detected from 10.150.10.x range)
-ups_server_ip: 10.150.10.44  # Fallback only if auto-detection fails - consider using IP address
+ups_server_ip: 10.150.10.44 # Fallback only if auto-detection fails - consider using IP address
 ups_user: monuser
 
 # IMPORTANT: For maximum reliability during power outages, consider adding

--- a/ansible/k3s_setup_tools.yml
+++ b/ansible/k3s_setup_tools.yml
@@ -6,12 +6,12 @@
 
   tasks:
     - name: Update apt cache
-      apt:
+      ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 3600
 
     - name: Install vim and git
-      apt:
+      ansible.builtin.apt:
         name:
           - vim
           - git

--- a/ansible/roles/jellyfin_backup/tasks/main.yml
+++ b/ansible/roles/jellyfin_backup/tasks/main.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: /root/.config/rclone
     state: directory
-    mode: '0700'
+    mode: "0700"
     owner: root
     group: root
 
@@ -20,7 +20,7 @@
   ansible.builtin.template:
     src: rclone.conf.j2
     dest: /root/.config/rclone/rclone.conf
-    mode: '0600'
+    mode: "0600"
     owner: root
     group: root
   no_log: true
@@ -29,14 +29,14 @@
   ansible.builtin.template:
     src: mnt_library_backup.sh.j2
     dest: /usr/local/bin/mnt_library_backup.sh
-    mode: '0755'
+    mode: "0755"
     owner: root
     group: root
 
 - name: Remove legacy cron job (not managed by ansible)
   ansible.builtin.lineinfile:
     path: /var/spool/cron/crontabs/root
-    regexp: '^0 0 \* \* \* /usr/local/bin/mnt_library_backup\.sh$'
+    regexp: "^0 0 \\* \\* \\* /usr/local/bin/mnt_library_backup\\.sh$"
     state: absent
   failed_when: false
 
@@ -53,6 +53,6 @@
   ansible.builtin.template:
     src: logrotate-mnt-library-backup.j2
     dest: /etc/logrotate.d/mnt-library-backup
-    mode: '0644'
+    mode: "0644"
     owner: root
     group: root

--- a/ansible/roles/netdata/defaults/main.yml
+++ b/ansible/roles/netdata/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Netdata installation and claiming configuration
 netdata_claim_url: https://app.netdata.cloud
-netdata_claim_token: "{{ vault_netdata_claim_token }}"  # Set per host group or leave empty to skip claiming
-netdata_claim_rooms: "{{ vault_netdata_default_claim_rooms }}"  # Set per host group or leave empty to skip claiming
+netdata_claim_token: "{{ vault_netdata_claim_token }}" # Set per host group or leave empty to skip claiming
+netdata_claim_rooms: "{{ vault_netdata_default_claim_rooms }}" # Set per host group or leave empty to skip claiming
 netdata_enable_auto_updates: true

--- a/ansible/roles/netdata/handlers/main.yml
+++ b/ansible/roles/netdata/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Reload netdata claiming
-  command: /usr/sbin/netdatacli reload-claiming-state
+  ansible.builtin.command: /usr/sbin/netdatacli reload-claiming-state
   failed_when: false  # May fail if service not fully started yet
   changed_when: true
 
 - name: Clean up netdata-repo package
-  file:
+  ansible.builtin.file:
     path: /tmp/netdata-repo.deb
     state: absent

--- a/ansible/roles/netdata/tasks/main.yml
+++ b/ansible/roles/netdata/tasks/main.yml
@@ -1,31 +1,31 @@
 ---
 - name: Check if netdata-repo package is already installed
-  command: dpkg-query -W -f='${Status}' netdata-repo
+  ansible.builtin.command: dpkg-query -W -f='${Status}' netdata-repo
   register: netdata_repo_check
   failed_when: false
   changed_when: false
 
 - name: Set fact if netdata-repo is installed
-  set_fact:
+  ansible.builtin.set_fact:
     netdata_repo_installed: "{{ 'install ok installed' in netdata_repo_check.stdout }}"
 
 - name: Download netdata-repo package
-  get_url:
+  ansible.builtin.get_url:
     url: https://repo.netdata.cloud/repos/repoconfig/ubuntu/jammy/netdata-repo_5-1+ubuntu22.04_all.deb
     dest: /tmp/netdata-repo.deb
-    mode: '0644'
+    mode: "0644"
   when: not netdata_repo_installed
   register: netdata_download
   notify: Clean up netdata-repo package
 
 - name: Check if downloaded package exists
-  stat:
+  ansible.builtin.stat:
     path: /tmp/netdata-repo.deb
   register: netdata_deb_file
   when: not netdata_repo_installed
 
 - name: Install netdata-repo package
-  apt:
+  ansible.builtin.apt:
     deb: /tmp/netdata-repo.deb
     state: present
   when:
@@ -34,27 +34,27 @@
     - netdata_deb_file.stat.exists
 
 - name: Update apt cache
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
 
 # Distro packages are built with --disable-cloud, so state: latest
 # ensures official repo package (with cloud support) replaces them
-- name: Install netdata  # noqa: package-latest
-  apt:
+- name: Install netdata # noqa: package-latest
+  ansible.builtin.apt:
     name: netdata
     state: latest
 
 - name: Check if already claimed
-  stat:
+  ansible.builtin.stat:
     path: /etc/netdata/claim.conf
   register: netdata_claim_file
   when: netdata_claim_token | length > 0
 
 - name: Create claiming configuration
-  copy:
+  ansible.builtin.copy:
     dest: /etc/netdata/claim.conf
-    mode: '0640'
+    mode: "0640"
     owner: root
     group: netdata
     content: |
@@ -70,12 +70,12 @@
   no_log: true
 
 - name: Check if netdata-updater script exists
-  stat:
+  ansible.builtin.stat:
     path: /usr/libexec/netdata/netdata-updater.sh
   register: netdata_updater_script
 
 - name: Enable netdata auto-updates
-  command: /usr/libexec/netdata/netdata-updater.sh --enable-auto-updates
+  ansible.builtin.command: /usr/libexec/netdata/netdata-updater.sh --enable-auto-updates
   args:
     creates: /etc/cron.daily/netdata-updater
   when:
@@ -83,18 +83,18 @@
     - netdata_updater_script.stat.exists
 
 - name: Ensure netdata service is started and enabled
-  systemd:
+  ansible.builtin.systemd:
     name: netdata
     state: started
     enabled: true
 
 - name: Wait for netdata to connect to cloud
-  pause:
+  ansible.builtin.pause:
     seconds: 10
   when: netdata_claim_token | length > 0
 
 - name: Verify netdata cloud connection
-  command: netdatacli aclk-state
+  ansible.builtin.command: netdatacli aclk-state
   register: aclk_status
   changed_when: false
   failed_when: "'Claimed: No' in aclk_status.stdout or 'Online: No' in aclk_status.stdout"

--- a/ansible/roles/nut/defaults/main.yml
+++ b/ansible/roles/nut/defaults/main.yml
@@ -16,5 +16,5 @@ ups_monitor_pass: "{{ vault_ups_monitor_pass }}"
 
 # Client configuration
 # Default NUT server (pve004) - used if detection doesn't find a server
-ups_server_ip: 10.150.10.44  # pve004
+ups_server_ip: 10.150.10.44 # pve004
 ups_user: monuser

--- a/ansible/roles/nut/handlers/main.yml
+++ b/ansible/roles/nut/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Restart NUT services
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ item }}"
     state: restarted
     enabled: true
@@ -10,7 +10,7 @@
   when: nut_mode == 'server'
 
 - name: Restart NUT client services
-  systemd:
+  ansible.builtin.systemd:
     name: nut-monitor
     state: restarted
     enabled: true

--- a/ansible/roles/nut/tasks/client.yml
+++ b/ansible/roles/nut/tasks/client.yml
@@ -1,39 +1,39 @@
 ---
 - name: Find UPS server hostname from detected hosts
-  set_fact:
+  ansible.builtin.set_fact:
     dynamic_ups_server_hostname: "{{ item }}"
   when: hostvars[item].has_ups | default(false)
   loop: "{{ ansible_play_hosts }}"
   run_once: false
 
 - name: Extract 10.150.10.x IP from UPS server
-  set_fact:
+  ansible.builtin.set_fact:
     dynamic_ups_server_ip: "{{ hostvars[dynamic_ups_server_hostname].ansible_all_ipv4_addresses | select('match', '^10\\.150\\.10\\.') | first }}"
   when: dynamic_ups_server_hostname is defined
 
 - name: Use dynamic IP or configured fallback
-  set_fact:
+  ansible.builtin.set_fact:
     ups_server_ip: "{{ dynamic_ups_server_ip | default(ups_server_ip) }}"
     ups_server_source: "{{ 'dynamically detected (10.150.10.x IP)' if dynamic_ups_server_ip is defined else 'fallback default' }}"
 
 - name: Display UPS server being used
-  debug:
+  ansible.builtin.debug:
     msg:
       - "Configuring {{ inventory_hostname }} as NUT client"
       - "UPS server: {{ ups_server_ip }} ({{ ups_server_source }})"
 
 - name: Set NUT mode to netclient
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/nut/nut.conf
-    regexp: '^MODE='
-    line: 'MODE=netclient'
-    mode: '0640'
+    regexp: "^MODE="
+    line: "MODE=netclient"
+    mode: "0640"
     create: true
 
 - name: Configure upsmon.conf for full network monitoring
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: /etc/nut/upsmon.conf
-    mode: '0600'
+    mode: "0600"
     create: true
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     block: |
@@ -52,14 +52,14 @@
   no_log: true
 
 - name: Disable nut-server on clients
-  systemd:
+  ansible.builtin.systemd:
     name: nut-server
     state: stopped
     enabled: false
 
 - name: Disable nut-driver on clients (in case node was previously a server)
-  systemd:
+  ansible.builtin.systemd:
     name: "nut-driver@{{ ups_name }}"
     state: stopped
     enabled: false
-  failed_when: false  # Don't fail if service doesn't exist
+  failed_when: false # Don't fail if service doesn't exist

--- a/ansible/roles/nut/tasks/detect.yml
+++ b/ansible/roles/nut/tasks/detect.yml
@@ -1,11 +1,11 @@
 ---
 - name: Check if configured UPS port exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ ups_port }}"
   register: ups_port_check
 
 - name: Test UPS serial communication (looking for SM response)
-  shell: |
+  ansible.builtin.shell: |
     stty -F {{ ups_port }} 2400 raw -echo && (exec 3<>{{ ups_port }}; echo "Y" >&3; timeout 1 cat <&3; exec 3>&-)
   register: ups_serial_test
   failed_when: false
@@ -13,7 +13,7 @@
   when: ups_port_check.stat.exists
 
 - name: Debug serial test output
-  debug:
+  ansible.builtin.debug:
     msg:
       - "Serial test stdout: '{{ ups_serial_test.stdout | default('') }}'"
       - "Serial test stderr: '{{ ups_serial_test.stderr | default('') }}'"
@@ -21,7 +21,7 @@
   when: ups_port_check.stat.exists
 
 - name: Set fact if UPS is detected (SM response found)
-  set_fact:
+  ansible.builtin.set_fact:
     has_ups: true
     detected_nut_mode: server
   when:
@@ -30,11 +30,11 @@
     - "'SM' in ups_serial_test.stdout"
 
 - name: Set fact if no UPS detected
-  set_fact:
+  ansible.builtin.set_fact:
     has_ups: false
     detected_nut_mode: client
   when: not (ups_port_check.stat.exists and ups_serial_test.stdout is defined and 'SM' in ups_serial_test.stdout)
 
 - name: Display detection result
-  debug:
+  ansible.builtin.debug:
     msg: "{{ inventory_hostname }}: UPS {{ 'FOUND - configuring as SERVER' if has_ups else 'not found - configuring as CLIENT' }}"

--- a/ansible/roles/nut/tasks/install.yml
+++ b/ansible/roles/nut/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install NUT
-  apt:
+  ansible.builtin.apt:
     name: nut
     state: present
     update_cache: true

--- a/ansible/roles/nut/tasks/main.yml
+++ b/ansible/roles/nut/tasks/main.yml
@@ -1,24 +1,23 @@
 ---
 - name: Detect UPS presence on this host
-  include_tasks: detect.yml
+  ansible.builtin.include_tasks: detect.yml
   when: nut_mode == 'auto' or nut_mode is not defined
 
 - name: Set nut_mode from detection if auto
-  set_fact:
+  ansible.builtin.set_fact:
     nut_mode: "{{ detected_nut_mode }}"
   when: (nut_mode == 'auto' or nut_mode is not defined) and detected_nut_mode is defined
 
 - name: Display NUT mode
-  debug:
+  ansible.builtin.debug:
     msg: "{{ inventory_hostname }}: Configured as {{ nut_mode | upper }}"
 
 - name: Include common installation tasks
-  include_tasks: install.yml
-
+  ansible.builtin.include_tasks: install.yml
 - name: Include server configuration
-  include_tasks: server.yml
+  ansible.builtin.include_tasks: server.yml
   when: nut_mode == 'server'
 
 - name: Include client configuration
-  include_tasks: client.yml
+  ansible.builtin.include_tasks: client.yml
   when: nut_mode == 'client'

--- a/ansible/roles/nut/tasks/server.yml
+++ b/ansible/roles/nut/tasks/server.yml
@@ -1,8 +1,8 @@
 ---
 - name: Configure ups.conf
-  copy:
+  ansible.builtin.copy:
     dest: /etc/nut/ups.conf
-    mode: '0640'
+    mode: "0640"
     content: |
       [{{ ups_name }}]
       driver = {{ ups_driver }}
@@ -11,9 +11,9 @@
   notify: Restart NUT services
 
 - name: Configure upsd.users
-  copy:
+  ansible.builtin.copy:
     dest: /etc/nut/upsd.users
-    mode: '0640'  # Must be group-readable so nut-server can read it (runs as 'nut' user)
+    mode: "0640" # Must be group-readable so nut-server can read it (runs as 'nut' user)
     owner: root
     group: nut
     content: |
@@ -29,24 +29,24 @@
   no_log: true
 
 - name: Configure upsd.conf to listen on all interfaces
-  copy:
+  ansible.builtin.copy:
     dest: /etc/nut/upsd.conf
-    mode: '0640'
+    mode: "0640"
     content: |
       LISTEN 0.0.0.0
   notify: Restart NUT services
 
 - name: Configure nut.conf to standalone
-  copy:
+  ansible.builtin.copy:
     dest: /etc/nut/nut.conf
-    mode: '0640'
+    mode: "0640"
     content: "MODE=standalone\n"
   notify: Restart NUT services
 
 - name: Configure upsmon.conf completely
-  copy:
+  ansible.builtin.copy:
     dest: /etc/nut/upsmon.conf
-    mode: '0600'
+    mode: "0600"
     content: |
       MONITOR {{ ups_name }}@localhost 1 {{ ups_admin_user }} {{ ups_admin_pass }} master
       MINSUPPLIES 1
@@ -63,13 +63,13 @@
   no_log: true
 
 - name: Add nut user to dialout group
-  user:
+  ansible.builtin.user:
     name: nut
     groups: dialout
     append: true
 
 - name: Ensure nut-server is started and enabled
-  systemd:
+  ansible.builtin.systemd:
     name: nut-server
     state: started
     enabled: true

--- a/ansible/roles/proxmox/handlers/main.yml
+++ b/ansible/roles/proxmox/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart pveproxy
-  systemd:
+  ansible.builtin.systemd:
     name: pveproxy
     state: restarted

--- a/ansible/roles/proxmox/tasks/main.yml
+++ b/ansible/roles/proxmox/tasks/main.yml
@@ -1,9 +1,7 @@
 ---
 - name: Configure repositories
-  include_tasks: repositories.yml
-
+  ansible.builtin.include_tasks: repositories.yml
 - name: Install default packages
-  include_tasks: packages.yml
-
+  ansible.builtin.include_tasks: packages.yml
 - name: Remove subscription nag
-  include_tasks: subscription-nag.yml
+  ansible.builtin.include_tasks: subscription-nag.yml

--- a/ansible/roles/proxmox/tasks/packages.yml
+++ b/ansible/roles/proxmox/tasks/packages.yml
@@ -1,10 +1,10 @@
 ---
 - name: Update apt cache
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
 
 - name: Install default Proxmox packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ proxmox_default_packages }}"
     state: present

--- a/ansible/roles/proxmox/tasks/repositories.yml
+++ b/ansible/roles/proxmox/tasks/repositories.yml
@@ -1,40 +1,40 @@
 ---
 - name: Disable Proxmox Enterprise repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb https://enterprise.proxmox.com/debian/pve bookworm pve-enterprise"
     state: absent
     filename: pve-enterprise
     update_cache: false
 
 - name: Add Proxmox no-subscription repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription"
     state: present
     filename: pve-install-repo
     update_cache: false
 
 - name: Disable Ceph Enterprise repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb https://enterprise.proxmox.com/debian/ceph-quincy bookworm enterprise"
     state: absent
     filename: ceph
     update_cache: false
 
 - name: Add Ceph Quincy no-subscription repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://download.proxmox.com/debian/ceph-quincy bookworm no-subscription"
     state: present
     filename: ceph
     update_cache: false
 
 - name: Ensure pvetest repository is disabled
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://download.proxmox.com/debian/pve bookworm pvetest"
     state: absent
     filename: pvetest-for-beta
     update_cache: false
 
 - name: Update apt cache
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600

--- a/ansible/roles/proxmox/tasks/subscription-nag.yml
+++ b/ansible/roles/proxmox/tasks/subscription-nag.yml
@@ -3,28 +3,29 @@
 # Based on: https://github.com/community-scripts/ProxmoxVE/blob/main/tools/pve/post-pve-install.sh
 
 - name: Check if proxmoxlib.js exists
-  stat:
+  ansible.builtin.stat:
     path: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
   register: proxmoxlib_file
 
 - name: Backup proxmoxlib.js before patching
-  copy:
+  ansible.builtin.copy:
     src: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
     dest: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js.bak
     remote_src: true
-    mode: '0644'
+    mode: "0644"
     force: false
   when: proxmoxlib_file.stat.exists
 
 - name: Check if already patched
-  command: grep -q "NoMoreNagging" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+  ansible.builtin.command: grep -q "NoMoreNagging" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
   register: already_patched
   failed_when: false
   changed_when: false
   when: proxmoxlib_file.stat.exists
 
 - name: Patch proxmoxlib.js to remove subscription nag
-  command: sed -i.bak -e "/data\.status/ s/!//" -e "/data\.status/ s/active/NoMoreNagging/" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+  ansible.builtin.command: sed -i.bak -e "/data\.status/ s/!//" -e "/data\.status/ s/active/NoMoreNagging/"
+    /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
   when:
     - proxmoxlib_file.stat.exists
     - already_patched is not skipped
@@ -34,15 +35,15 @@
   notify: Restart pveproxy
 
 - name: Create persistence script directory
-  file:
+  ansible.builtin.file:
     path: /usr/local/bin
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Create nag removal persistence script
-  copy:
+  ansible.builtin.copy:
     dest: /usr/local/bin/pve-remove-nag.sh
-    mode: '0755'
+    mode: "0755"
     content: |
       #!/bin/bash
       # Auto-remove Proxmox subscription nag after package updates
@@ -55,9 +56,9 @@
       fi
 
 - name: Create apt hook to persist nag removal
-  copy:
+  ansible.builtin.copy:
     dest: /etc/apt/apt.conf.d/99-pve-no-subscription-nag
-    mode: '0644'
+    mode: "0644"
     content: |
       DPkg::Post-Invoke {
         "if [ -x /usr/local/bin/pve-remove-nag.sh ]; then /usr/local/bin/pve-remove-nag.sh; fi";

--- a/ansible/roles/tailscale/defaults/main.yml
+++ b/ansible/roles/tailscale/defaults/main.yml
@@ -9,5 +9,5 @@ tailscale_cert_path: /etc/pve/local/pveproxy-ssl.pem
 tailscale_key_path: /etc/pve/local/pveproxy-ssl.key
 tailscale_cert_owner: root
 tailscale_cert_group: www-data
-tailscale_cert_mode: '0640'
+tailscale_cert_mode: "0640"
 tailscale_cert_renewal_days: 30

--- a/ansible/roles/tailscale/handlers/main.yml
+++ b/ansible/roles/tailscale/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Display Proxmox access message
-  debug:
+  ansible.builtin.debug:
     msg: "Proxmox Web UI now accessible via https://{{ tailscale_hostname.stdout }}:8006"

--- a/ansible/roles/tailscale/tasks/auth.yml
+++ b/ansible/roles/tailscale/tasks/auth.yml
@@ -1,12 +1,12 @@
 ---
 - name: Check if Tailscale is authenticated
-  command: tailscale status
+  ansible.builtin.command: tailscale status
   register: tailscale_status
   failed_when: false
   changed_when: false
 
 - name: Check for hostname conflicts in Tailscale network
-  shell: set -o pipefail; tailscale status --json 2>/dev/null | jq -r '.Peer[].HostName' | grep -c "^{{ inventory_hostname }}$" || echo "0"
+  ansible.builtin.shell: set -o pipefail; tailscale status --json 2>/dev/null | jq -r '.Peer[].HostName' | grep -c "^{{ inventory_hostname }}$" || echo "0"
   args:
     executable: /bin/bash
   register: hostname_conflict_check
@@ -15,7 +15,7 @@
   when: tailscale_status.rc != 0
 
 - name: Fail if hostname already exists in Tailscale
-  fail:
+  ansible.builtin.fail:
     msg: |
       Hostname '{{ inventory_hostname }}' already exists in your Tailscale network.
       This will cause Tailscale to name this device '{{ inventory_hostname }}-1' instead.
@@ -29,7 +29,7 @@
     - hostname_conflict_check.stdout | default('0') | int > 0
 
 - name: Authenticate Tailscale
-  command: >
+  ansible.builtin.command: >
     tailscale up --authkey={{ tailscale_auth_key }}
     --hostname={{ inventory_hostname }}
     {% if tailscale_tags is defined %}--advertise-tags={{ tailscale_tags }}{% endif %}
@@ -40,7 +40,7 @@
   no_log: true
 
 - name: Update Tailscale tags on already-authenticated devices
-  command: >
+  ansible.builtin.command: >
     tailscale up
     --hostname={{ inventory_hostname }}
     {% if tailscale_tags is defined %}--advertise-tags={{ tailscale_tags }}{% endif %}
@@ -52,7 +52,7 @@
   changed_when: false
 
 - name: Enable Tailscale SSH (if not already set via up command)
-  command: tailscale set --ssh
+  ansible.builtin.command: tailscale set --ssh
   when:
     - tailscale_enable_ssh | default(true)
     - tailscale_status.rc == 0

--- a/ansible/roles/tailscale/tasks/certs.yml
+++ b/ansible/roles/tailscale/tasks/certs.yml
@@ -1,23 +1,23 @@
 ---
 - name: Fail if Tailscale is not authenticated
-  fail:
+  ansible.builtin.fail:
     msg: "Tailscale is not authenticated on {{ inventory_hostname }}. Run 'tailscale up' first."
   when: tailscale_status.rc != 0
 
 - name: Get Tailscale hostname
-  shell: set -o pipefail; tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//'
+  ansible.builtin.shell: set -o pipefail; tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//'
   args:
     executable: /bin/bash
   register: tailscale_hostname
   changed_when: false
 
 - name: Check if certificate exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ tailscale_cert_path }}"
   register: cert_file
 
 - name: Check certificate expiration
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     expiry=$(openssl x509 -enddate -noout -in {{ tailscale_cert_path }} | cut -d= -f2)
     expiry_epoch=$(date -d "$expiry" +%s)
@@ -31,17 +31,17 @@
   when: cert_file.stat.exists
 
 - name: Determine if certificate renewal needed
-  set_fact:
+  ansible.builtin.set_fact:
     needs_renewal: "{{ not cert_file.stat.exists or (cert_days_left.stdout | default('0') | int < tailscale_cert_renewal_days) }}"
 
 - name: Request Tailscale TLS certificate to temp location
-  command: tailscale cert --cert-file /tmp/pveproxy-ssl.pem --key-file /tmp/pveproxy-ssl.key {{ tailscale_hostname.stdout }}
+  ansible.builtin.command: tailscale cert --cert-file /tmp/pveproxy-ssl.pem --key-file /tmp/pveproxy-ssl.key {{ tailscale_hostname.stdout }}
   when: needs_renewal
   register: cert_result
   changed_when: cert_result.rc == 0
 
 - name: Copy certificate to Proxmox location
-  shell: |
+  ansible.builtin.shell: |
     cat /tmp/pveproxy-ssl.pem > {{ tailscale_cert_path }}
     chown {{ tailscale_cert_owner }}:{{ tailscale_cert_group }} {{ tailscale_cert_path }}
     chmod {{ tailscale_cert_mode }} {{ tailscale_cert_path }}
@@ -49,7 +49,7 @@
   changed_when: true
 
 - name: Copy key to Proxmox location
-  shell: |
+  ansible.builtin.shell: |
     cat /tmp/pveproxy-ssl.key > {{ tailscale_key_path }}
     chown {{ tailscale_cert_owner }}:{{ tailscale_cert_group }} {{ tailscale_key_path }}
     chmod {{ tailscale_cert_mode }} {{ tailscale_key_path }}
@@ -57,7 +57,7 @@
   changed_when: true
 
 - name: Clean up temp certificate files
-  file:
+  ansible.builtin.file:
     path: "/tmp/{{ item }}"
     state: absent
   loop:
@@ -66,7 +66,7 @@
   when: needs_renewal
 
 - name: Restart pveproxy service
-  systemd:
+  ansible.builtin.systemd:
     name: pveproxy
     state: restarted
   when: needs_renewal

--- a/ansible/roles/tailscale/tasks/install.yml
+++ b/ansible/roles/tailscale/tasks/install.yml
@@ -1,11 +1,11 @@
 ---
 - name: Detect OS distribution
-  set_fact:
+  ansible.builtin.set_fact:
     tailscale_distro: "{{ 'ubuntu' if ansible_facts['distribution'] == 'Ubuntu' else 'debian' }}"
     tailscale_codename: "{{ ansible_facts['distribution_release'] }}"
 
 - name: Ensure Tailscale GPG key is properly formatted
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     curl -fsSL https://pkgs.tailscale.com/stable/{{ tailscale_distro }}/{{ tailscale_codename }}.gpg | \
     gpg --dearmor > /usr/share/keyrings/tailscale-archive-keyring.gpg.tmp && \
@@ -15,23 +15,22 @@
     creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
 
 - name: Add Tailscale repository
-  copy:
-    content: "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] \
-      https://pkgs.tailscale.com/stable/{{ tailscale_distro }} \
-      {{ tailscale_codename }} main\n"
+  ansible.builtin.copy:
+    content: |
+      deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/{{ tailscale_distro }} {{ tailscale_codename }} main
     dest: /etc/apt/sources.list.d/tailscale.list
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
 
 - name: Update apt cache after adding Tailscale repo
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
   changed_when: false
 
 - name: Ensure required packages are installed
-  apt:
+  ansible.builtin.apt:
     name:
       - tailscale
       - jq

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -1,10 +1,8 @@
 ---
 - name: Include installation tasks
-  include_tasks: install.yml
-
+  ansible.builtin.include_tasks: install.yml
 - name: Include authentication tasks
-  include_tasks: auth.yml
-
+  ansible.builtin.include_tasks: auth.yml
 - name: Include certificate tasks
-  include_tasks: certs.yml
+  ansible.builtin.include_tasks: certs.yml
   when: tailscale_setup_proxmox_certs | default(false)

--- a/ansible/verify_nut.yml
+++ b/ansible/verify_nut.yml
@@ -6,26 +6,26 @@
 
   tasks:
     - name: Check if NUT is installed
-      command: which upsc
+      ansible.builtin.command: which upsc
       register: upsc_check
       failed_when: false
       changed_when: false
 
     - name: Determine if this is server or client
-      shell: set -o pipefail; grep "^MODE=" /etc/nut/nut.conf | cut -d= -f2
+      ansible.builtin.shell: set -o pipefail; grep "^MODE=" /etc/nut/nut.conf | cut -d= -f2
       args:
         executable: /bin/bash
       register: nut_mode_check
       changed_when: false
 
     - name: Query UPS status
-      command: upsc myups@10.150.10.44
+      ansible.builtin.command: upsc myups@10.150.10.44
       register: ups_status
       failed_when: false
       changed_when: false
 
     - name: Check nut-monitor service
-      systemd:
+      ansible.builtin.systemd:
         name: nut-monitor
         state: started
       check_mode: true
@@ -33,7 +33,7 @@
       failed_when: false
 
     - name: Check nut-server service (servers only)
-      systemd:
+      ansible.builtin.systemd:
         name: nut-server
         state: started
       check_mode: true
@@ -42,7 +42,7 @@
       when: nut_mode_check.stdout == "standalone"
 
     - name: Display verification results
-      debug:
+      ansible.builtin.debug:
         msg: |
           Host: {{ inventory_hostname }}
           NUT Installed: {{ 'Yes' if upsc_check.rc == 0 else 'No' }}
@@ -57,7 +57,7 @@
           UPS Load: {{ ups_status.stdout_lines | select('search', 'ups.load') | first if ups_status.rc == 0 else 'N/A' }}
 
     - name: Set verification status
-      set_fact:
+      ansible.builtin.set_fact:
         nut_healthy: "{{ upsc_check.rc == 0 and ups_status.rc == 0 and monitor_service.status.ActiveState == 'active' }}"
 
 - name: Summary
@@ -65,11 +65,11 @@
   gather_facts: false
   tasks:
     - name: Show healthy hosts
-      debug:
+      ansible.builtin.debug:
         msg: "✓ {{ inventory_hostname }} - NUT monitoring is healthy"
       when: nut_healthy | default(false)
 
     - name: Show unhealthy hosts
-      debug:
+      ansible.builtin.debug:
         msg: "✗ {{ inventory_hostname }} - NUT monitoring has issues"
       when: not (nut_healthy | default(false))


### PR DESCRIPTION
## Summary
- Convert all core module references to use `ansible.builtin.*` fully qualified names
- Auto-fixed 101 violations using `ansible-lint --fix`
- Manual fix for one line-length issue in tailscale/tasks/install.yml

## Changes
26 files updated across all roles and playbooks:
- `apt` → `ansible.builtin.apt`
- `copy` → `ansible.builtin.copy`
- `command` → `ansible.builtin.command`
- etc.

## Test plan
- [x] Verify ansible-lint passes in CI
- [x] Run `--check --diff` on a Proxmox host

Fixes part of #20 (Phase 2)