### PR TITLE
Fix ansible-lint risky-shell-pipe violations

### DIFF
--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -10,9 +10,8 @@ exclude_paths:
 
 # Skip specific rules for now (fix in future PR)
 skip_list:
-  - fqcn[action-core]  # TODO: Convert to FQCN in future
+  - fqcn[action-core]  # Fixed in PR #59
   - var-naming[no-role-prefix]  # TODO: Rename variables with role prefix
-  - risky-shell-pipe  # We use pipes in shell commands carefully
   - command-instead-of-module  # We use curl for GPG key to avoid issues
   - internal-error  # Expected - vault files need password
 

--- a/ansible/roles/tailscale/tasks/auth.yml
+++ b/ansible/roles/tailscale/tasks/auth.yml
@@ -6,7 +6,9 @@
   changed_when: false
 
 - name: Check for hostname conflicts in Tailscale network
-  shell: tailscale status --json 2>/dev/null | jq -r '.Peer[].HostName' | grep -c "^{{ inventory_hostname }}$" || echo "0"
+  shell: set -o pipefail; tailscale status --json 2>/dev/null | jq -r '.Peer[].HostName' | grep -c "^{{ inventory_hostname }}$" || echo "0"
+  args:
+    executable: /bin/bash
   register: hostname_conflict_check
   failed_when: false
   changed_when: false

--- a/ansible/roles/tailscale/tasks/certs.yml
+++ b/ansible/roles/tailscale/tasks/certs.yml
@@ -5,7 +5,9 @@
   when: tailscale_status.rc != 0
 
 - name: Get Tailscale hostname
-  shell: tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//'
+  shell: set -o pipefail; tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//'
+  args:
+    executable: /bin/bash
   register: tailscale_hostname
   changed_when: false
 
@@ -16,11 +18,14 @@
 
 - name: Check certificate expiration
   shell: |
+    set -o pipefail
     expiry=$(openssl x509 -enddate -noout -in {{ tailscale_cert_path }} | cut -d= -f2)
     expiry_epoch=$(date -d "$expiry" +%s)
     now_epoch=$(date +%s)
     days_left=$(( ($expiry_epoch - $now_epoch) / 86400 ))
     echo $days_left
+  args:
+    executable: /bin/bash
   register: cert_days_left
   changed_when: false
   when: cert_file.stat.exists

--- a/ansible/roles/tailscale/tasks/install.yml
+++ b/ansible/roles/tailscale/tasks/install.yml
@@ -6,10 +6,12 @@
 
 - name: Ensure Tailscale GPG key is properly formatted
   shell: |
+    set -o pipefail
     curl -fsSL https://pkgs.tailscale.com/stable/{{ tailscale_distro }}/{{ tailscale_codename }}.gpg | \
     gpg --dearmor > /usr/share/keyrings/tailscale-archive-keyring.gpg.tmp && \
     mv /usr/share/keyrings/tailscale-archive-keyring.gpg.tmp /usr/share/keyrings/tailscale-archive-keyring.gpg
   args:
+    executable: /bin/bash
     creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
 
 - name: Add Tailscale repository

--- a/ansible/verify_nut.yml
+++ b/ansible/verify_nut.yml
@@ -12,7 +12,9 @@
       changed_when: false
 
     - name: Determine if this is server or client
-      shell: grep "^MODE=" /etc/nut/nut.conf | cut -d= -f2
+      shell: set -o pipefail; grep "^MODE=" /etc/nut/nut.conf | cut -d= -f2
+      args:
+        executable: /bin/bash
       register: nut_mode_check
       changed_when: false
 


### PR DESCRIPTION
## Summary
- Add `set -o pipefail` to all shell commands that use pipes
- Ensures errors in any part of a pipeline are caught, not just the last command

## Changes
- `roles/tailscale/tasks/auth.yml` - hostname conflict check
- `roles/tailscale/tasks/certs.yml` - get hostname, check cert expiration  
- `roles/tailscale/tasks/install.yml` - GPG key download
- `verify_nut.yml` - NUT mode check

## Test plan
- [ ] Verify ansible-lint passes in CI
- [ ] Run `--check --diff` on a Proxmox host

Completes Phase 2 of #20