### PR TITLE
Add Pi backup server infrastructure

### DIFF
--- a/ansible/backup-setup.yml
+++ b/ansible/backup-setup.yml
@@ -1,0 +1,20 @@
+---
+# Backup infrastructure setup
+# Configures Pi as backup server and Jellyfin as backup client
+
+- name: Configure backup server (Pi)
+  hosts: backup_servers
+  become: true
+  vars_files:
+    - vault.yml
+  roles:
+    - tailscale
+    - backup_server
+
+- name: Configure backup client (Jellyfin)
+  hosts: jellyfin
+  become: true
+  vars_files:
+    - vault.yml
+  roles:
+    - backup_client

--- a/ansible/inventory/homelab.yml
+++ b/ansible/inventory/homelab.yml
@@ -42,6 +42,16 @@ all:
             slurm-compute-02:
               ansible_host: 10.150.10.138
 
+    # Backup Servers
+    backup_servers:
+      hosts:
+        pibackup:
+          # Set ansible_host after finding Pi IP via nmap or DHCP leases
+          # ansible_host: 10.x.x.x
+          ansible_user: pi
+          backup_disk_device: /dev/sda1
+          backup_mount_point: /mnt/backup
+
     # Kubernetes Cluster (Currently decommissioned)
     # k3s_cluster:
     #   children:

--- a/ansible/roles/backup_client/defaults/main.yml
+++ b/ansible/roles/backup_client/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# Backup client defaults
+
+# Backup target - Pi backup server via Tailscale
+backup_server_host: pibackup
+backup_server_user: backup
+backup_server_repo_path: /mnt/backup/restic-repo
+
+# Restic password (same as server)
+restic_password: "{{ vault_restic_password }}"
+
+# Paths to backup
+backup_paths:
+  - /mnt/library
+
+# Paths to exclude
+backup_excludes:
+  - "*.tmp"
+  - "lost+found"
+  - "tmp/"
+
+# Schedule (cron format)
+backup_cron_hour: "2"
+backup_cron_minute: "0"
+
+# Retention policy
+backup_keep_daily: 7
+backup_keep_weekly: 4
+backup_keep_monthly: 6
+
+# Script and log locations
+backup_script_path: /usr/local/bin/backup-library.sh
+backup_log_path: /var/log/restic-backup.log

--- a/ansible/roles/backup_client/files/logrotate
+++ b/ansible/roles/backup_client/files/logrotate
@@ -1,0 +1,9 @@
+/var/log/restic-backup.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/ansible/roles/backup_client/tasks/main.yml
+++ b/ansible/roles/backup_client/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# Backup client role - installs restic, deploys backup script, configures cron
+
+- name: Include restic setup tasks
+  ansible.builtin.include_tasks: restic.yml

--- a/ansible/roles/backup_client/tasks/restic.yml
+++ b/ansible/roles/backup_client/tasks/restic.yml
@@ -1,0 +1,34 @@
+---
+# Install restic, deploy backup script, configure cron
+
+- name: Install restic
+  ansible.builtin.apt:
+    name: restic
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Deploy backup script
+  ansible.builtin.template:
+    src: backup.sh.j2
+    dest: "{{ backup_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Setup backup cron job
+  ansible.builtin.cron:
+    name: "Restic backup to Pi"
+    minute: "{{ backup_cron_minute }}"
+    hour: "{{ backup_cron_hour }}"
+    job: "{{ backup_script_path }}"
+    user: root
+    state: present
+
+- name: Deploy logrotate config
+  ansible.builtin.copy:
+    src: logrotate
+    dest: /etc/logrotate.d/restic-backup
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/roles/backup_client/templates/backup.sh.j2
+++ b/ansible/roles/backup_client/templates/backup.sh.j2
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Restic backup script - managed by Ansible
+# Backs up to Pi backup server over Tailscale
+
+LOGFILE="{{ backup_log_path }}"
+RESTIC_REPOSITORY="sftp:{{ backup_server_user }}@{{ backup_server_host }}:{{ backup_server_repo_path }}"
+RESTIC_PASSWORD="{{ restic_password }}"
+
+export RESTIC_REPOSITORY
+export RESTIC_PASSWORD
+
+# Function to log messages with timestamp
+log_message() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOGFILE"
+}
+
+# Trap Ctrl+C or TERM and log
+trap 'log_message "Backup interrupted"; exit 130' INT TERM
+
+log_message "Starting restic backup"
+
+# Check if backup server is reachable
+if ! ping -c 1 -W 5 {{ backup_server_host }} > /dev/null 2>&1; then
+    log_message "ERROR: Backup server {{ backup_server_host }} is not reachable"
+    exit 1
+fi
+
+# Run backup
+log_message "Backing up: {{ backup_paths | join(', ') }}"
+if restic backup \
+{% for path in backup_paths %}
+    "{{ path }}" \
+{% endfor %}
+{% for exclude in backup_excludes %}
+    --exclude "{{ exclude }}" \
+{% endfor %}
+    --verbose >> "$LOGFILE" 2>&1; then
+    log_message "Backup completed successfully"
+else
+    EXIT_CODE=$?
+    log_message "Backup failed with exit code $EXIT_CODE"
+    exit $EXIT_CODE
+fi
+
+# Run retention policy
+log_message "Applying retention policy"
+if restic forget \
+    --keep-daily {{ backup_keep_daily }} \
+    --keep-weekly {{ backup_keep_weekly }} \
+    --keep-monthly {{ backup_keep_monthly }} \
+    --prune >> "$LOGFILE" 2>&1; then
+    log_message "Retention policy applied successfully"
+else
+    EXIT_CODE=$?
+    log_message "Retention policy failed with exit code $EXIT_CODE"
+    exit $EXIT_CODE
+fi
+
+log_message "Backup process finished"

--- a/ansible/roles/backup_server/defaults/main.yml
+++ b/ansible/roles/backup_server/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Backup server defaults
+
+# Disk configuration (typically overridden per-host in inventory)
+backup_disk_device: /dev/sda1
+backup_mount_point: /mnt/backup
+backup_filesystem_type: ext4
+
+# Restic repository
+restic_repo_path: "{{ backup_mount_point }}/restic-repo"
+restic_password: "{{ vault_restic_password }}"
+
+# Backup user for restricted SSH access
+backup_user: backup
+backup_user_home: /home/backup
+
+# SSH authorized keys for backup clients
+backup_authorized_keys: []

--- a/ansible/roles/backup_server/handlers/main.yml
+++ b/ansible/roles/backup_server/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+# Handlers for backup_server role
+# Currently no handlers needed - disk mount is handled by mount module

--- a/ansible/roles/backup_server/tasks/disk.yml
+++ b/ansible/roles/backup_server/tasks/disk.yml
@@ -1,0 +1,30 @@
+---
+# Mount external backup disk
+
+- name: Ensure mount point directory exists
+  ansible.builtin.file:
+    path: "{{ backup_mount_point }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Check if disk is already formatted
+  ansible.builtin.command: blkid -s TYPE -o value {{ backup_disk_device }}
+  register: disk_filesystem
+  changed_when: false
+  failed_when: false
+
+- name: Format disk if not already formatted
+  community.general.filesystem:
+    fstype: "{{ backup_filesystem_type }}"
+    dev: "{{ backup_disk_device }}"
+  when: disk_filesystem.stdout == ""
+
+- name: Mount backup disk
+  ansible.posix.mount:
+    path: "{{ backup_mount_point }}"
+    src: "{{ backup_disk_device }}"
+    fstype: "{{ backup_filesystem_type }}"
+    opts: defaults,nofail
+    state: mounted

--- a/ansible/roles/backup_server/tasks/main.yml
+++ b/ansible/roles/backup_server/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# Backup server role - configures disk, restic repo, and SSH access
+
+- name: Include disk mount tasks
+  ansible.builtin.include_tasks: disk.yml
+
+- name: Include restic setup tasks
+  ansible.builtin.include_tasks: restic.yml
+
+- name: Include SSH access tasks
+  ansible.builtin.include_tasks: ssh.yml

--- a/ansible/roles/backup_server/tasks/restic.yml
+++ b/ansible/roles/backup_server/tasks/restic.yml
@@ -1,0 +1,38 @@
+---
+# Install restic and initialize repository
+
+- name: Install restic
+  ansible.builtin.apt:
+    name: restic
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create restic repository directory
+  ansible.builtin.file:
+    path: "{{ restic_repo_path }}"
+    state: directory
+    owner: "{{ backup_user }}"
+    group: "{{ backup_user }}"
+    mode: "0700"
+
+- name: Check if restic repo is already initialized
+  ansible.builtin.stat:
+    path: "{{ restic_repo_path }}/config"
+  register: restic_repo_config
+
+- name: Initialize restic repository
+  ansible.builtin.command: restic init --repo {{ restic_repo_path }}
+  environment:
+    RESTIC_PASSWORD: "{{ restic_password }}"
+  when: not restic_repo_config.stat.exists
+  become: true
+  become_user: "{{ backup_user }}"
+  changed_when: true
+
+- name: Set correct ownership on restic repo
+  ansible.builtin.file:
+    path: "{{ restic_repo_path }}"
+    owner: "{{ backup_user }}"
+    group: "{{ backup_user }}"
+    recurse: true

--- a/ansible/roles/backup_server/tasks/ssh.yml
+++ b/ansible/roles/backup_server/tasks/ssh.yml
@@ -1,0 +1,27 @@
+---
+# Create backup user and configure SSH access
+
+- name: Create backup user
+  ansible.builtin.user:
+    name: "{{ backup_user }}"
+    home: "{{ backup_user_home }}"
+    shell: /bin/bash
+    system: false
+    create_home: true
+
+- name: Ensure .ssh directory exists for backup user
+  ansible.builtin.file:
+    path: "{{ backup_user_home }}/.ssh"
+    state: directory
+    owner: "{{ backup_user }}"
+    group: "{{ backup_user }}"
+    mode: "0700"
+
+- name: Deploy authorized keys for backup user
+  ansible.builtin.template:
+    src: authorized_keys.j2
+    dest: "{{ backup_user_home }}/.ssh/authorized_keys"
+    owner: "{{ backup_user }}"
+    group: "{{ backup_user }}"
+    mode: "0600"
+  when: backup_authorized_keys | length > 0

--- a/ansible/roles/backup_server/templates/authorized_keys.j2
+++ b/ansible/roles/backup_server/templates/authorized_keys.j2
@@ -1,0 +1,4 @@
+# Managed by Ansible - backup client authorized keys
+{% for key in backup_authorized_keys %}
+{{ key }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- Add `backup_servers` inventory group with `pibackup` host
- Create `backup_server` role: mounts 2TB USB disk, installs restic, initializes encrypted repo
- Create `backup_client` role: deploys backup script with daily cron (2am), logrotate
- Add `backup-setup.yml` playbook to configure both server and client

## Architecture
```
┌─────────────┐    restic backup     ┌─────────────┐
│  Jellyfin   │ ──────────────────▶  │  Pi Backup  │
│ /mnt/library│     (Tailscale)      │ /mnt/backup │
└─────────────┘                      └─────────────┘
     2am daily cron                   2TB USB disk
```

Jellyfin pushes backups to the Pi over Tailscale (SFTP). The Pi is passive storage.

## Pre-deploy Steps
1. Find Pi IP: `nmap -sn 10.x.x.0/24` or check DHCP leases
2. Update inventory with Pi IP: `ansible_host: 10.x.x.x`
3. Add vault entry: `ansible-vault edit vault.yml`
   - Add: `vault_restic_password: "<secure-password>"`

## Test plan
- [ ] SSH to Pi, verify disk mounted: `df -h /mnt/backup`
- [ ] Check restic repo: `restic -r /mnt/backup/restic-repo snapshots`
- [ ] Run manual backup from Jellyfin: `/usr/local/bin/backup-library.sh`
- [ ] Verify snapshot created
- [ ] Test restore of single file