### PR TITLE
Update reading list: track Jeff suggestions and add HPE prep checkboxes

### DIFF
--- a/notes/reading-list.md
+++ b/notes/reading-list.md
@@ -1,9 +1,8 @@
-# Reading List
+ Reading List
 
 ## Currently Reading
 
 - **Punishment-Free Parenting: The Brain-Based Way to Raise Kids Without Raising Your Voice** by Jon Fogel
-- **Dare to Lead** by Brené Brown
 
 ## Finished
 
@@ -32,6 +31,23 @@
   - Completed: ~October 12, 2025
   - Note: Author was interviewed by Jon Stewart on The Daily Show (July 14, 2025)
 
+## Before March 2 (HPE Prep)
+
+### Priority 1: Read before day one
+- [ ] **Radical Candor** by Kim Scott (re-read, audiobook -- listen while driving/errands)
+- [ ] **The Goal** by Eliyahu Goldratt (theory of constraints -- directly maps to managing shared data center resources)
+- [ ] **Legacy** by James Kerr (team culture -- critical when inheriting a team that lost a 40-year leader)
+
+### Priority 2: Skim key chapters, use as reference ongoing
+- **Time Management for System Administrators** by Thomas Limoncelli (quick read, understand your team's world)
+- **Wiring the Winning Organization** by Gene Kim and Steven Spear (structuring and optimizing technical teams)
+
+### Priority 3: Ongoing reference (don't try to cover-to-cover before start)
+- **Practice of System and Network Administration, The: DevOps and other Best Practices for Enterprise IT, Volume 1** by Thomas Limoncelli, Strata Chalup, Christina Hogan
+- **Practice of Cloud System Administration, The: DevOps and SRE Practices for Web Services, Volume 2** by Thomas Limoncelli, Strata Chalup, Christina Hogan
+- **Site Reliability Engineering: How Google Runs Production Systems** by Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
+- **An Elegant Puzzle: Systems of Engineering Management** by Will Larson (recommended)
+
 ## Want to Read
 
 - **The Money Player: The Confessions of America's Greatest Table Tennis Champion and Hustler** by Marty Reisman
@@ -42,9 +58,9 @@
 
 ## From Jeff
 
-- **Legacy**
-- **The Goal**
+- ~~**Legacy**~~ (moved to HPE Prep)
+- ~~**The Goal**~~ (moved to HPE Prep)
+- **Dare to Lead** (returned to library, not started)
 - **Empowered**
 - **Start with Why**
-- **Wiring the Wining Organization**
-
+- ~~**Wiring the Winning Organization**~~ (moved to HPE Prep)


### PR DESCRIPTION
## Summary
- Add missing "Dare to Lead" to From Jeff section (was never tracked after original addition)
- Update Dare to Lead status: returned to library, not started
- Add checkboxes to Priority 1 HPE prep books for progress tracking
- Strikethrough Jeff items that were moved to HPE Prep section

## Test plan
- [ ] Verify all 6 original Jeff suggestions are now tracked
- [ ] Verify checkboxes render correctly in GitHub