### PR TITLE
Add Netdata fleet health check to deploy workflow

### DIFF
--- a/.github/workflows/ansible-deploy.yml
+++ b/.github/workflows/ansible-deploy.yml
@@ -67,6 +67,52 @@ jobs:
             $LIMIT_FLAG \
             -v
 
+      - name: Netdata fleet health check
+        if: >-
+          success() &&
+          (github.event.inputs.playbook == 'netdata_install.yml' ||
+           github.event.inputs.playbook == 'site.yml')
+        env:
+          NETDATA_API_TOKEN: ${{ secrets.NETDATA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          SPACE="fdc5c86c-40e1-4c04-ba72-2c270dbcc2f2"
+          ROOM="b9b8607a-73ca-4de7-b5ae-86c3c74766be"
+          API_URL="https://app.netdata.cloud/api/v2/spaces/${SPACE}/rooms/${ROOM}/nodes"
+
+          echo "Querying Netdata Cloud for node status..."
+          RESPONSE=$(curl -sf -H "Authorization: Bearer ${NETDATA_API_TOKEN}" \
+            -H "Accept: application/json" \
+            "${API_URL}")
+
+          # Parse node names and states
+          NODES=$(echo "$RESPONSE" | jq -r '.nodes[] | "\(.name)\t\(.state)"')
+
+          # Print summary table
+          echo ""
+          echo "Node Health Summary"
+          echo "===================="
+          printf "%-25s %s\n" "NODE" "STATE"
+          printf "%-25s %s\n" "----" "-----"
+          echo "$NODES" | while IFS=$'\t' read -r name state; do
+            printf "%-25s %s\n" "$name" "$state"
+          done
+          echo ""
+
+          # Check for unreachable nodes
+          UNREACHABLE=$(echo "$NODES" | grep -v "reachable$" || true)
+          if [ -n "$UNREACHABLE" ]; then
+            echo "::error::Unreachable nodes detected after deploy:"
+            echo "$UNREACHABLE" | while IFS=$'\t' read -r name state; do
+              echo "  - ${name}: ${state}"
+            done
+            exit 1
+          fi
+
+          TOTAL=$(echo "$NODES" | wc -l | tr -d ' ')
+          echo "All ${TOTAL} nodes are reachable."
+
       - name: Clean up vault password
         if: always()
         run: |

--- a/journal/2026-02-12-netdata-health-check-ci.md
+++ b/journal/2026-02-12-netdata-health-check-ci.md
@@ -1,0 +1,38 @@
+# Netdata Fleet Health Check in CI/CD
+
+**Date:** 2026-02-12
+
+## Summary
+
+Added a post-deploy health check step to the `ansible-deploy.yml` GitHub Actions workflow. After running Netdata or site-wide playbooks, the workflow now queries the Netdata Cloud API to verify all nodes are reachable.
+
+## Problem
+
+The deploy workflow relied solely on Ansible's exit code to determine success. A playbook could complete without errors but leave a node in a degraded state — the agent might not start, or a config issue could make it unreachable from Netdata Cloud. There was no post-deploy verification.
+
+## Solution
+
+Added a new step between the playbook run and vault cleanup that:
+
+1. Queries the Netdata Cloud API (`/api/v2/spaces/{space}/rooms/{room}/nodes`) for all nodes in the "All nodes" room
+2. Prints a summary table of node names and states
+3. Fails the workflow if any node is not in `reachable` state
+
+The step only runs for `netdata_install.yml` and `site.yml` playbooks — skipped for unrelated runs like `verify_nut.yml`.
+
+## Implementation Details
+
+- Uses `NETDATA_API_TOKEN` stored as a GitHub Actions secret
+- Space ID: `fdc5c86c-40e1-4c04-ba72-2c270dbcc2f2`
+- Room: "All nodes" (`b9b8607a-73ca-4de7-b5ae-86c3c74766be`)
+- Uses `jq` to parse the API response and `grep` to detect unreachable nodes
+- Outputs GitHub Actions error annotations (`::error::`) for visibility in the Actions UI
+
+## Required Setup
+
+- Generate a new Netdata Cloud API token (previous one was revoked)
+- Add it as `NETDATA_API_TOKEN` in the repo's GitHub Actions secrets
+
+## Files Changed
+
+- `.github/workflows/ansible-deploy.yml` — added "Netdata fleet health check" step

--- a/site/content/posts/2026-02-12-netdata-health-check-ci.md
+++ b/site/content/posts/2026-02-12-netdata-health-check-ci.md
@@ -1,0 +1,44 @@
+---
+title: "Netdata Fleet Health Check in CI/CD"
+date: 2026-02-12
+draft: true
+tags: ["netdata", "github-actions", "ansible", "ci-cd", "monitoring"]
+---
+
+
+**Date:** 2026-02-12
+
+## Summary
+
+Added a post-deploy health check step to the `ansible-deploy.yml` GitHub Actions workflow. After running Netdata or site-wide playbooks, the workflow now queries the Netdata Cloud API to verify all nodes are reachable.
+
+## Problem
+
+The deploy workflow relied solely on Ansible's exit code to determine success. A playbook could complete without errors but leave a node in a degraded state — the agent might not start, or a config issue could make it unreachable from Netdata Cloud. There was no post-deploy verification.
+
+## Solution
+
+Added a new step between the playbook run and vault cleanup that:
+
+1. Queries the Netdata Cloud API (`/api/v2/spaces/{space}/rooms/{room}/nodes`) for all nodes in the "All nodes" room
+2. Prints a summary table of node names and states
+3. Fails the workflow if any node is not in `reachable` state
+
+The step only runs for `netdata_install.yml` and `site.yml` playbooks — skipped for unrelated runs like `verify_nut.yml`.
+
+## Implementation Details
+
+- Uses `NETDATA_API_TOKEN` stored as a GitHub Actions secret
+- Space ID: `fdc5c86c-40e1-4c04-ba72-2c270dbcc2f2`
+- Room: "All nodes" (`b9b8607a-73ca-4de7-b5ae-86c3c74766be`)
+- Uses `jq` to parse the API response and `grep` to detect unreachable nodes
+- Outputs GitHub Actions error annotations (`::error::`) for visibility in the Actions UI
+
+## Required Setup
+
+- Generate a new Netdata Cloud API token (previous one was revoked)
+- Add it as `NETDATA_API_TOKEN` in the repo's GitHub Actions secrets
+
+## Files Changed
+
+- `.github/workflows/ansible-deploy.yml` — added "Netdata fleet health check" step


### PR DESCRIPTION
## Summary

- Adds a post-deploy health check step to `ansible-deploy.yml` that queries the Netdata Cloud API to verify all nodes are reachable
- Only runs for `netdata_install.yml` and `site.yml` playbooks (skips `verify_nut.yml`)
- Prints a summary table of node names/states and fails the workflow if any node is unreachable
- Includes journal entry documenting the change

## Required Setup

Add `NETDATA_API_TOKEN` as a GitHub Actions secret (generate a fresh token since the previous one was revoked).

## Test plan

- [ ] Add `NETDATA_API_TOKEN` secret to the repo
- [ ] Trigger a manual deploy with `netdata_install.yml` and confirm health check step passes
- [ ] Verify the step is skipped when running `verify_nut.yml`