### PR TITLE
Fix Netdata health check API response parsing

### DIFF
--- a/.github/workflows/ansible-deploy.yml
+++ b/.github/workflows/ansible-deploy.yml
@@ -86,8 +86,16 @@ jobs:
             -H "Accept: application/json" \
             "${API_URL}")
 
-          # Parse node names and states
-          NODES=$(echo "$RESPONSE" | jq -r '.nodes[] | "\(.name)\t\(.state)"')
+          # Debug: show response structure
+          echo "Response type: $(echo "$RESPONSE" | jq -r 'type')"
+          echo "Response keys/length: $(echo "$RESPONSE" | jq -r 'if type == "object" then keys | join(", ") else length end')"
+          echo "First element sample: $(echo "$RESPONSE" | jq -c 'if type == "array" then .[0] else .nodes[0] // .data[0] // empty end' 2>/dev/null | head -c 500)"
+
+          # Parse node names and states (handle both array and object responses)
+          NODES=$(echo "$RESPONSE" | jq -r '
+            (if type == "array" then . else .nodes // .data // [] end)[]
+            | "\(.name // .hostname // .node_id)\t\(.state // .status // "unknown")"
+          ')
 
           # Print summary table
           echo ""


### PR DESCRIPTION
## Summary

- Fix jq parsing to handle both array and object responses from Netdata Cloud API
- Add debug output to show response type, keys, and a sample element
- Use fallback field names (name/hostname/node_id, state/status) for flexibility

Follows up on #188 — the health check step failed because the API returns a top-level array, not `{nodes: [...]}`.

## Test plan

- [ ] Trigger deploy with `netdata_install.yml` and verify health check passes