### PR TITLE
Remove debug output from Netdata health check

### DIFF
--- a/.github/workflows/ansible-deploy.yml
+++ b/.github/workflows/ansible-deploy.yml
@@ -86,16 +86,8 @@ jobs:
             -H "Accept: application/json" \
             "${API_URL}")
 
-          # Debug: show response structure
-          echo "Response type: $(echo "$RESPONSE" | jq -r 'type')"
-          echo "Response keys/length: $(echo "$RESPONSE" | jq -r 'if type == "object" then keys | join(", ") else length end')"
-          echo "First element sample: $(echo "$RESPONSE" | jq -c 'if type == "array" then .[0] else .nodes[0] // .data[0] // empty end' 2>/dev/null | head -c 500)"
-
-          # Parse node names and states (handle both array and object responses)
-          NODES=$(echo "$RESPONSE" | jq -r '
-            (if type == "array" then . else .nodes // .data // [] end)[]
-            | "\(.name // .hostname // .node_id)\t\(.state // .status // "unknown")"
-          ')
+          # Parse node names and states
+          NODES=$(echo "$RESPONSE" | jq -r '.[] | "\(.name)\t\(.state)"')
 
           # Print summary table
           echo ""


### PR DESCRIPTION
## Summary

- Remove debug lines (response type, keys, sample element) added to diagnose API format
- Simplify jq to `.[] | "\(.name)\t\(.state)"` now that format is confirmed

## Test plan

- [x] Verified in run 21966991080: response is a top-level array with `name` and `state` fields