### PR TITLE
Add Google Analytics to lab site

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -2,6 +2,7 @@ baseURL = 'https://lab.8devops.com/'
 languageCode = 'en-us'
 title = 'DevOps & Homelab Adventures'
 theme = 'PaperMod'
+googleAnalytics = 'G-P0LDRLNCXJ'
 
 # Enable RSS feeds for subscriptions
 [outputs]


### PR DESCRIPTION
## Summary
- Enable GA4 tracking for lab.8devops.com via Hugo's built-in `googleAnalytics` config param
- PaperMod theme picks this up automatically — no template changes needed

## Test plan
- [ ] Rebuild site with `hugo` and verify the GA script tag appears in page source
- [ ] Deploy and confirm real-time tracking in the GA4 dashboard