### PR TITLE
Update gitignore for PII backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,5 @@ stts/
 # Build artifacts
 *.tar.gz
 
-# KubeCraft course emails (contain PII)
-mvb_k8s/emails/
+# KubeCraft course emails (contain PII - scrub headers before re-adding)
+.mvb_k8s_backup/


### PR DESCRIPTION
## Summary
- Updated `.gitignore` to ignore `.mvb_k8s_backup/` (local PII backup)
- Removed stale `mvb_k8s/emails/` entry since that directory was scrubbed from history

## Context
Closes part of #218 — the `mvb_k8s/` directory contained `.eml` files with personal email addresses in headers on this public repo. The directory was removed from git history with `git filter-repo`, and a local backup is kept in `.mvb_k8s_backup/` for later sanitization.