### PR TITLE
Re-add KubeCraft emails as sanitized markdown

### DIFF
--- a/mvb_k8s/emails/Checking-on-your-learning-progress.md
+++ b/mvb_k8s/emails/Checking-on-your-learning-progress.md
@@ -1,0 +1,100 @@
+# Checking on your learning progress
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Thu, 11 Dec 2025 19:33:35 +0000
+
+---
+
+Hey Adam,
+
+​
+
+Just checking in on your learning progress.
+
+It's very important that you don't just read these emails.
+
+You have to do the work that's described in them.
+
+​
+
+That's one of the biggest mistakes I made early on I my career.
+
+I would read book after book, and consume one video course after
+the other.
+
+All without ever touching the keyboard.
+
+It felt like I was learning. But when I finally sat down to put
+it into practice, I realized I had forgotten all of it.
+
+​
+
+You will only learn if you do the practical exercises that are
+described in these emails.
+
+So please do them!
+
+​
+
+Overwhelmed by the text format?
+
+Scrolling over these emails, it might feel intimidating.
+
+There's lots of technical jargon being thrown around.
+
+Even though I do my best to keep the words as simple as possible,
+making it accessible is challenging in e-mail format.
+
+My normal mode of teaching is very different.
+
+I have a unique teaching style that people like a lot:
+
+I design my courses as if I'm teaching you on the job.
+
+It's as if you are a junior engineer and we sit down together
+with our laptops in the same room and I simply show you how
+everything works.
+
+This allows me to go very deep and to explain all of the details.
+
+As an example, remember when we learned about pods? I tried to do
+that in one email.
+
+But the video course module on pods alone is almost an hour long.
+
+Imagine how much more I can teach you in that hour, showing you
+all of the code examples and practical applications.
+
+​
+
+So if the written format isn't working out for you, you can join
+KubeCraft (
+https://ed9688f7.click.convertkit-mail2.com/v8uggm0865cmux4zrp2sghv3e98lls9hpke07/9qhzhnhd9mpmk2a9/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to get access to 60+ hours of in-depth video courses where I'll
+teach you everything.
+
+​CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/v8uggm0865cmux4zrp2sghv3e98lls9hpke07/9qhzhnhd9mpmk2a9/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to get access right now.
+
+​
+
+Tomorrow we continue with deploying our first functional
+application: a self-hosted bookmark manager.
+
+​
+
+See you there!
+
+Mischa
+
+​
+
+​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/v8uggm0865cmux4zrp2sghv3e98lls9hpke07
+) | Update your profile (
+https://preferences.convertkit-mail2.com/v8uggm0865cmux4zrp2sghv3e98lls9hpke07
+)

--- a/mvb_k8s/emails/Day-2-Deployments---The-Magic-of-Self-Healing-Applications.md
+++ b/mvb_k8s/emails/Day-2-Deployments---The-Magic-of-Self-Healing-Applications.md
@@ -1,0 +1,368 @@
+# Day 2: Deployments - The Magic of Self-Healing Applications
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Tue, 09 Dec 2025 15:31:25 +0000
+
+---
+
+Hey Adam,
+
+Yesterday you deployed a single pod.
+
+Today you learn why that’s not how anyone runs production
+workloads. And what to use instead.
+
+The Problem with Pods
+
+Remember when you deleted your nginx pod? It was gone. Forever.
+If that was serving real traffic, your users would see errors.
+
+Pods are ephemeral. They’re designed to be temporary. They can
+die for many reasons:
+
+* The node they’re running on crashes
+* They run out of memory
+* A bug causes them to exit
+* You accidentally delete them
+* Kubernetes needs to move them during maintenance
+
+If you manually create pods with kubectl run, nobody is watching
+them. When they die, they stay dead.
+
+This is where Deployments come in.
+
+​
+
+What is a Deployment?
+
+A Deployment is a higher-level object that manages pods for you.
+
+Instead of saying “create this pod,” you say “I want 3 copies of
+this pod running at all times.”
+
+​
+
+Kubernetes then:
+
+- Creates 3 pods
+
+- Monitors their health
+
+- Replaces any that fail
+
+- Maintains your desired count no matter what
+
+​
+
+You declare the desired state. Kubernetes maintains it. This is
+called declarative configuration. One of the core principles of
+Kubernetes.
+
+​
+
+The Controller Pattern
+
+Behind the scenes, Kubernetes uses something called a controller.
+A controller is a loop that constantly:
+
+* Observes the current state
+* Compares it to the desired state
+* Takes action to reconcile any differences
+
+For Deployments, the Deployment Controller watches your pods. If
+you said “3 replicas” and only 2 are running, it creates another
+one. If 4 are running somehow, it terminates one.
+
+This happens automatically, 24/7, without any human intervention.
+
+This is how companies run hundreds of services reliably. Not by
+having engineers babysit pods, but by declaring what they want
+and letting controllers maintain it.
+
+​
+
+Let’s Create a Deployment
+
+​
+
+Run this command:​
+kubectl create deployment my-app --image=nginx --replicas=3
+​
+
+Let’s break down what this does:
+
+* create deployment creates a Deployment object
+* my-app names it “my-app”
+* --image=nginx uses the nginx container image
+* --replicas=3 runs 3 copies
+
+Check your pods:
+
+​
+kubectl get pods
+​
+
+​
+NAME READY STATUS RESTARTS AGE
+my-app-6d9f9c6b9b-7xjdk 1/1 Running 0 10s
+my-app-6d9f9c6b9b-bm2qf 1/1 Running 0 10s
+my-app-6d9f9c6b9b-tnvrx 1/1 Running 0 10s
+​
+
+Three pods, all running. Notice the names have a random suffix.
+That’s because these pods are managed by the Deployment, not
+created manually.
+
+View the Deployment:
+
+​
+kubectl get deployment my-app
+​
+
+​
+NAME READY UP-TO-DATE AVAILABLE AGE
+my-app 3/3 3 3 30s
+​
+
+* READY 3/3 means 3 out of 3 desired pods are ready
+* UP-TO-DATE means 3 pods match the current configuration
+* AVAILABLE means 3 pods are available to serve traffic
+
+​
+
+The Self-Healing Demo
+
+Now let’s break something and watch Kubernetes fix it.
+
+First, open a second terminal window and run:
+
+​
+kubectl get pods --watch
+​
+
+This will continuously show pod status changes. Keep this
+visible.
+
+In your first terminal, copy one of your pod names and delete it:
+
+​
+kubectl delete pod my-app-6d9f9c6b9b-7xjdk
+​
+
+Watch your second terminal.
+
+You’ll see something like:
+
+​
+my-app-6d9f9c6b9b-7xjdk 1/1 Terminating 0 2m
+my-app-6d9f9c6b9b-7xjdk 0/1 Terminating 0 2m
+my-app-6d9f9c6b9b-r4pmn 0/1 Pending 0 0s
+my-app-6d9f9c6b9b-r4pmn 0/1 ContainerCreating 0 0s
+my-app-6d9f9c6b9b-r4pmn 1/1 Running 0 2s
+​
+
+Within seconds, Kubernetes: 1. Detected a pod was terminated 2.
+Noticed only 2 replicas exist but 3 are desired 3. Created a new
+pod to replace it 4. Started the container
+
+You’re back to 3 healthy pods. No manual intervention required.
+
+Press Ctrl+C to stop the watch.
+
+​
+
+Scaling Your Deployment
+
+What if you need more capacity? Maybe traffic spiked and 3 pods
+aren’t enough.
+
+Scale up to 5:
+
+​
+kubectl scale deployment my-app --replicas=5
+​
+
+Check pods:
+
+​
+kubectl get pods
+​
+
+Five pods running. Kubernetes created 2 more.
+
+Scale down to 2:
+
+​
+kubectl scale deployment my-app --replicas=2
+​
+
+Kubernetes terminates 3 pods, leaving you with 2.
+
+In production, you’d often use a Horizontal Pod Autoscaler that
+automatically scales based on CPU or memory usage. But manual
+scaling is how you understand the fundamentals.
+
+​
+
+Understanding ReplicaSets
+
+When you create a Deployment, it actually creates another object
+called a ReplicaSet.
+
+​
+kubectl get replicaset
+​
+
+​
+NAME DESIRED CURRENT READY AGE
+my-app-6d9f9c6b9b 2 2 2 5m
+​
+
+The hierarchy is:
+
+​
+Deployment
+└── ReplicaSet
+└── Pods
+​
+
+* Deployment manages rollouts and rollbacks
+* ReplicaSet ensures the right number of pods exist
+* Pods actually run the containers
+
+​
+
+You rarely interact with ReplicaSets directly. Deployments manage
+them for you.
+
+But knowing they exist helps you understand what’s happening
+under the hood.
+
+​
+
+Deployment Rollouts
+
+Deployments also handle updates gracefully.
+
+Let’s say you want to change the nginx image version:
+
+​
+kubectl set image deployment/my-app nginx=nginx:1.25
+​
+
+Watch what happens:
+
+​
+kubectl rollout status deployment/my-app
+​
+
+Kubernetes creates new pods with the new image, waits for them to
+be healthy, then terminates the old pods. This is called a
+rolling update.
+
+At no point are zero pods running. Traffic keeps flowing during
+the update.
+
+You can also check rollout history:
+
+​
+kubectl rollout history deployment/my-app
+​
+
+And if something goes wrong, roll back:
+
+​
+kubectl rollout undo deployment/my-app
+​
+
+This is how companies deploy new code dozens of times per day
+without downtime.
+
+​
+
+Labels and Selectors
+
+How does the Deployment know which pods belong to it?
+
+Labels.
+
+Every pod created by your Deployment has a label app=my-app. The
+Deployment uses a selector to find pods with that label.
+
+See the labels:
+
+​
+kubectl get pods --show-labels
+​
+
+​
+NAME READY STATUS LABELS
+my-app-6d9f9c6b9b-bm2qf 1/1 Running
+app=my-app,pod-template-hash=6d9f9c6b9b
+my-app-6d9f9c6b9b-tnvrx 1/1 Running
+app=my-app,pod-template-hash=6d9f9c6b9b
+​
+
+Labels are key-value pairs attached to objects. They’re how
+Kubernetes organizes and selects things.
+
+You could have multiple deployments in the same namespace like
+“frontend”, “backend”, “database”, each with different labels.
+Services (which we’ll cover tomorrow) use labels to know which
+pods to send traffic to.
+
+​
+
+Clean Up (Don’t Do This Yet)
+
+We’ll use this deployment tomorrow. But when you eventually want
+to delete it:
+
+​
+kubectl delete deployment my-app
+​
+
+This deletes the Deployment, which deletes the ReplicaSet, which
+deletes all the pods. Clean.
+
+​
+
+What You Learned Today
+
+* Pods are ephemeral and can die at any time. They won’t come
+back on their own
+* Deployments manage pods and ensure your desired replica count
+is maintained
+* Self-healing means Kubernetes automatically replaces failed
+pods
+* Scaling lets you change replica count with a single command
+* ReplicaSets are the object between Deployments and Pods
+* Rolling updates deploy new versions without downtime
+* Labels and selectors are how Kubernetes organizes and finds
+objects
+
+​
+
+Tomorrow, we tackle networking. Your pods are running, but how do
+you actually connect to them? That’s where Services come in.
+
+Keep the deployment running. We’ll need it.
+
+Mischa
+
+​
+
+P.S. Self-healing is just the beginning. In KubeCraft, you’ll
+learn horizontal pod autoscaling, pod disruption budgets, rolling
+update strategies, and GitOps workflows that deploy automatically
+when you push to Git. This is what separates tutorial-watchers
+from engineers who get hired. CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/d0uqqkp5zncmu4kgke3hmhzl7d544ilhonw5m/n2hohvhvrq5zomt6/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to get access.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/d0uqqkp5zncmu4kgke3hmhzl7d544ilhonw5m
+) | Update your profile (
+https://preferences.convertkit-mail2.com/d0uqqkp5zncmu4kgke3hmhzl7d544ilhonw5m
+)

--- a/mvb_k8s/emails/Day-3-Kubernetes-Networking.md
+++ b/mvb_k8s/emails/Day-3-Kubernetes-Networking.md
@@ -1,0 +1,214 @@
+# Day 3: Kubernetes Networking
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Wed, 10 Dec 2025 15:29:05 +0000
+
+---
+
+Hey Adam,
+
+​
+
+You have a deployment running with multiple nginx pods.
+
+But try to visit them in your browser. You can’t.
+
+Those pods have IP addresses, but they’re internal to the
+cluster. And even if you could reach them, what happens when a
+pod dies and gets replaced? The new pod gets a new IP address.
+
+This is the networking problem Kubernetes solves with Services.
+
+​
+
+The Problem: Pod IPs Are Ephemeral
+
+​
+
+Let’s see the current state:
+
+​
+kubectl get pods -o wide
+​
+
+The -o wide flag shows more columns, including IP addresses:
+
+​
+NAME READY STATUS IP NODE
+my-app-6d9f9c6b9b-bm2qf 1/1 Running 10.42.0.15
+rancher-desktop
+my-app-6d9f9c6b9b-tnvrx 1/1 Running 10.42.0.16
+rancher-desktop
+​
+
+Each pod has its own IP (10.42.0.x). These IPs work inside the
+cluster - pods can talk to each other using them.
+
+But here’s the problem:
+
+* These IPs are only accessible from inside the cluster
+* They change whenever a pod restarts
+* You have multiple pods - which one do you connect to?
+
+Imagine your frontend needs to talk to your backend. If you
+hardcode the backend pod’s IP, your app breaks the moment that
+pod restarts.
+
+The Solution: Services
+
+A Service is a stable endpoint that sits in front of your pods.
+
+Instead of connecting to pod IPs directly, you connect to the
+Service. The Service knows which pods belong to it (using labels)
+and distributes traffic to them.
+
+Think of it like a load balancer - one stable address that routes
+to multiple backends.
+
+Service Types
+
+Kubernetes has several Service types. The three main ones:
+
+ClusterIP (default)
+
+Only accessible from inside the cluster. Gets a stable internal
+IP.
+
+Use case: Backend services that other pods need to reach.
+
+NodePort
+
+Opens a port on every node in the cluster. Accessible from
+outside the cluster via :.
+
+Use case: Quick external access for testing.
+
+LoadBalancer
+
+Creates an external load balancer (in cloud environments). Gets a
+public IP address.
+
+Use case: Production traffic from the internet.
+
+​
+
+For local development, we’ll use ClusterIP with port-forwarding.
+
+This is the most common pattern for learning.
+
+​
+
+Create a Service
+
+Make sure your deployment is running:
+
+​
+kubectl get deployment my-app
+​
+
+Now expose it:
+
+​
+kubectl expose deployment my-app --port=80 --target-port=80
+​
+
+What this does:
+
+* Creates a Service called “my-app” (same name as the deployment)
+* Listens on port 80
+* Forwards traffic to port 80 on the pods
+
+​
+
+Check it:
+
+​
+kubectl get services
+​
+
+​
+NAME TYPE CLUSTER-IP EXTERNAL-IP PORT(S)
+AGE
+kubernetes ClusterIP 10.43.0.1 443/TCP 2d
+my-app ClusterIP 10.43.245.127 80/TCP 5s
+​
+
+Your service has a ClusterIP (10.43.245.127). This IP is stable -
+it won’t change even if all the pods behind it are replaced.
+
+​
+
+How the Service Finds Pods
+
+Services use label selectors to find their pods.
+
+When you ran kubectl expose deployment my-app, Kubernetes
+automatically configured the Service to select pods with the
+label app=my-app.
+
+See the details:
+
+​
+kubectl describe service my-app
+​
+
+Look for these lines:
+
+​
+Selector: app=my-app
+Endpoints: 10.42.0.15:80,10.42.0.16:80
+​
+
+Selector is the label query used to find pods. Endpoints are the
+actual pod IPs currently backing this service.
+
+Delete a pod and run describe again. You’ll see the Endpoints
+update automatically.
+
+​
+
+Accessing the Service
+
+The ClusterIP is only reachable from inside the cluster. Your
+laptop isn’t inside the cluster.
+
+To access it from your browser, use port-forward:
+
+​
+kubectl port-forward service/my-app 8080:80
+​
+
+This creates a tunnel: - Your laptop’s port 8080 → Service port
+80 → Pod port 80
+
+Open your browser: http://localhost:8080
+
+You should see “Welcome to nginx!”
+
+​
+
+What Just Happened
+
+Let’s trace the path:
+
+* Your browser requests localhost:8080
+* kubectl forwards that to the my-app Service on port 80
+* The Service picks one of its endpoint pods
+* The request reaches nginx in that pod
+* nginx returns the welcome page
+* Response travels back through the tunnel
+
+Keep the port-forward running. Open another terminal and delete a
+pod:
+
+​
+kubectl delete pod CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/75u55z3wgdc2uk878zkbzhwe8n966bnh5oxrl/n2hohvhvr0g8d0t6/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+)to join.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/75u55z3wgdc2uk878zkbzhwe8n966bnh5oxrl
+) | Update your profile (
+https://preferences.convertkit-mail2.com/75u55z3wgdc2uk878zkbzhwe8n966bnh5oxrl
+)

--- a/mvb_k8s/emails/Day-4-The-real-way-to-do-Kubernetes.md
+++ b/mvb_k8s/emails/Day-4-The-real-way-to-do-Kubernetes.md
@@ -1,0 +1,455 @@
+# Day 4: The real way to do Kubernetes
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Thu, 11 Dec 2025 15:31:55 +0000
+
+---
+
+Hey Adam,
+
+​
+
+So far, you’ve been running kubectl commands like:
+
+​
+kubectl create deployment my-app --image=nginx --replicas=3
+kubectl expose deployment my-app --port=80
+​
+
+This works for learning. But it’s not how anyone runs production
+Kubernetes.
+
+The problem with commands:
+
+* No record of what you did
+* Hard to reproduce
+* Can’t review changes before applying
+* No version control
+* “What was that flag again?”
+
+The solution: YAML manifests.
+
+​
+
+Infrastructure as Code
+
+In Kubernetes, everything is defined in YAML files. Your
+deployments, services, storage, configuration. All written as
+code.
+
+This is called declarative configuration. Instead of running
+commands (imperative: “do this”), you write files that describe
+the desired state (declarative: “this is what I want”).
+
+You commit these files to Git. Now your infrastructure is:
+
+Version controlled. See who changed what and when.
+
+Reviewable. Pull requests for infrastructure changes.
+
+Reproducible. Anyone can deploy the same thing.
+
+Documented. The YAML is the documentation.
+
+​
+
+This is the foundation of GitOps, a practice where Git is the
+source of truth for your infrastructure. Push to Git, and your
+cluster updates automatically.
+
+​
+
+Anatomy of a Kubernetes YAML File
+
+Let’s look at a Deployment manifest:
+
+yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+name: my-app
+labels:
+app: my-app
+spec:
+replicas: 3
+selector:
+matchLabels:
+app: my-app
+template:
+metadata:
+labels:
+app: my-app
+spec:
+containers:
+- name: nginx
+image: nginx:1.25
+ports:
+- containerPort: 80
+​
+
+Let’s break down every section:
+
+apiVersion: apps/v1
+
+Kubernetes has multiple API versions. Different resource types
+live in different API groups:
+
+v1 contains core resources (Pods, Services, ConfigMaps).
+
+apps/v1 contains application resources (Deployments,
+StatefulSets).
+
+networking.k8s.io/v1 contains networking (Ingress,
+NetworkPolicy).
+
+​
+
+For Deployments, it’s apps/v1.
+
+​
+
+kind: Deployment
+
+What type of resource you’re creating.
+
+Kubernetes has dozens of resource types: Deployment, Service,
+Pod, ConfigMap, Secret, PersistentVolumeClaim, and more.
+
+metadata:
+
+Information about the resource:
+
+name is the resource name (must be unique in the namespace).
+
+labels are key-value pairs for organization and selection.
+
+namespace specifies which namespace (default if not specified).
+
+annotations are additional metadata (not used for selection).
+
+spec:
+
+The specification, meaning what you actually want. This varies by
+resource type.
+
+For a Deployment spec:
+
+replicas: 3
+
+How many pods to run.
+
+selector:
+
+How the Deployment finds its pods. Must match the labels in the
+pod template.
+
+yaml
+selector:
+matchLabels:
+app: my-app
+​
+
+This says “manage pods that have the label app=my-app.”
+
+template:
+
+The pod template - what each pod looks like. This has its own
+metadata and spec:
+
+yaml
+template:
+metadata:
+labels:
+app: my-app # Must match selector
+spec:
+containers:
+- name: nginx
+image: nginx:1.25
+ports:
+- containerPort: 80
+​
+
+The pod template’s labels MUST match the selector. This is how
+the Deployment knows which pods belong to it.
+
+containers:
+
+A list of containers to run in each pod. Each container has:
+
+name is the container name.
+
+image is the container image (from Docker Hub or other registry).
+
+ports defines the ports the container listens on. env sets
+environment variables (we’ll use this later).
+
+resources sets CPU/memory requests and limits.
+
+volumeMounts defines where to mount storage.
+
+​
+
+Create Your First YAML File
+
+Let’s do this for real. First, clean up anything running:
+
+​
+kubectl delete deployment my-app
+kubectl delete service my-app
+​
+
+Create a file called deployment.yaml:
+
+yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+name: my-app
+labels:
+app: my-app
+spec:
+replicas: 3
+selector:
+matchLabels:
+app: my-app
+template:
+metadata:
+labels:
+app: my-app
+spec:
+containers:
+- name: nginx
+image: nginx:1.25
+ports:
+- containerPort: 80
+​
+
+Save it. Now apply it:
+
+​
+kubectl apply -f deployment.yaml
+​
+
+​
+deployment.apps/my-app created
+​
+
+Check your pods:
+
+​
+kubectl get pods
+​
+
+Three pods running - created from your YAML file.
+
+​
+
+The Power of apply
+
+kubectl apply is idempotent. Run it again:
+
+​
+kubectl apply -f deployment.yaml
+​
+
+​
+deployment.apps/my-app unchanged
+​
+
+Nothing changed because the current state already matches the
+desired state.
+
+Now edit the file. Change replicas: 3 to replicas: 5.
+
+​
+
+Apply again:
+
+​
+kubectl apply -f deployment.yaml
+​
+
+​
+deployment.apps/my-app configured
+​
+
+“Configured” means Kubernetes detected the difference and updated
+the deployment. Check pods:
+
+​
+kubectl get pods
+​
+
+Five pods now. You didn’t run a “scale” command. You changed the
+file and applied it. This is declarative configuration.
+
+​
+
+Multiple Resources in One File
+
+You can define multiple resources in a single YAML file using ---
+as a separator.
+
+Create app.yaml:
+
+yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+name: my-app
+labels:
+app: my-app
+spec:
+replicas: 2
+selector:
+matchLabels:
+app: my-app
+template:
+metadata:
+labels:
+app: my-app
+spec:
+containers:
+- name: nginx
+image: nginx:1.25
+ports:
+- containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+name: my-app
+labels:
+app: my-app
+spec:
+selector:
+app: my-app
+ports:
+- port: 80
+targetPort: 80
+​
+
+Delete the old deployment first:
+
+​
+kubectl delete -f deployment.yaml
+​
+
+Apply the new file:
+
+​
+kubectl apply -f app.yaml
+​
+
+​
+deployment.apps/my-app created
+service/my-app created
+​
+
+Both resources created with one command. Check them:
+
+​
+kubectl get deployment,service
+​
+
+​
+
+Generating YAML from Commands
+
+​
+
+Don’t want to write YAML from scratch? Use the dry run flag:
+
+​
+kubectl create deployment test --image=nginx --replicas=2
+--dry-run=client -o yaml
+​
+
+This outputs the YAML without creating anything. You can redirect
+it to a file:
+
+​
+kubectl create deployment test --image=nginx --replicas=2
+--dry-run=client -o yaml > test.yaml
+​
+
+Same for services:
+
+​
+kubectl create service clusterip test --tcp=80:80
+--dry-run=client -o yaml
+​
+
+This is a huge time saver, especially when you’re learning.
+Generate the YAML, then customize it.
+
+Pro tip for exams: The CKA and CKAD exams are timed. Using
+--dry-run=client -o yaml to generate YAML quickly is essential.
+
+​
+
+Viewing Existing Resources as YAML
+
+Want to see how an existing resource is defined?
+
+​
+kubectl get deployment my-app -o yaml
+​
+
+This dumps the full YAML, including defaults Kubernetes added.
+It’s verbose, but useful for understanding what’s possible.
+
+​
+
+Deleting with YAML
+
+Just like apply, you can delete using the file:
+
+​
+kubectl delete -f app.yaml
+​
+
+This removes everything defined in the file.
+
+​
+
+What You Learned Today
+
+YAML manifests define resources declaratively.
+
+apiVersion, kind, metadata, spec form the structure of every
+Kubernetes resource.
+
+kubectl apply creates or updates resources to match the file.
+
+Multiple resources can live in one file separated by ---.
+
+–dry-run=client -o yaml generates YAML from commands.
+
+Infrastructure as Code means your cluster state is version
+controlled.
+
+​
+
+Tomorrow we continue with the next lesson.
+
+Mischa
+
+​
+
+P.S. YAML is just the beginning. Real Kubernetes engineers use
+Helm charts for templating, Kustomize for environment overlays,
+and GitOps tools like ArgoCD that automatically sync your cluster
+to Git. Inside KubeCraft, you learn all of it - the full
+production workflow, not just basics. CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/n4uzz385kgbqu8gpg2lf6h68xz5ggflhg7pqx/reh8hohmxr7nllc2/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to apply.
+
+​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/n4uzz385kgbqu8gpg2lf6h68xz5ggflhg7pqx
+) | Update your profile (
+https://preferences.convertkit-mail2.com/n4uzz385kgbqu8gpg2lf6h68xz5ggflhg7pqx
+)

--- a/mvb_k8s/emails/Day-5-Deploy-something-youll-actually-use.md
+++ b/mvb_k8s/emails/Day-5-Deploy-something-youll-actually-use.md
@@ -1,0 +1,462 @@
+# Day 5: Deploy something you’ll actually use
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Fri, 12 Dec 2025 15:29:14 +0000
+
+---
+
+Hey Adam,
+
+Let’s be honest.
+
+Deploying nginx over and over gets boring. It doesn’t stick.
+
+You do the tutorial, close your laptop, and forget everything by
+next week.
+
+Today we change that.
+
+We’re deploying Linkding (
+https://ed9688f7.click.convertkit-mail2.com/38u77drlv9hduorlr0pcrh4qgw2nns7h6rqzn/n2hohvhvr9xrqof6/aHR0cHM6Ly9naXRodWIuY29tL3Npc3NicnVlY2tlci9saW5rZGluZw==
+), a self-hosted bookmark manager that you’ll actually use.
+
+I’ve been running Linkding on my own Kubernetes cluster for over
+a year. It’s genuinely useful:
+
+* Save bookmarks from any browser with a browser extension
+* Access them from any device: phone, tablet, other computers
+* Never lose a link again
+* Search through all your bookmarks instantly
+* Your data stays on YOUR infrastructure, not some company’s
+server
+
+This is what self-hosting on Kubernetes looks like. Real
+applications. Real value.
+
+And unlike nginx demos, you’ll want to keep this running.
+
+What We’re Building
+
+By the end of tomorrow, you’ll have:
+
+* Linkding running in its own namespace
+* Persistent storage so your bookmarks survive restarts
+* A service exposing the application
+* A working bookmark manager you can use daily
+
+Today we get Linkding running. Tomorrow we add persistent
+storage.
+
+Let’s go.
+
+Namespaces: Organizing Your Cluster
+
+Before we deploy, let’s learn about namespaces.
+
+A namespace is a way to organize resources in your cluster. Think
+of it like folders on your computer.
+
+Without namespaces, everything lives in the “default” namespace.
+That gets messy when you have multiple applications.
+
+With namespaces:
+
+* Each application gets its own space
+* Resource names only need to be unique within a namespace
+* You can set resource quotas per namespace
+* You can control access per namespace
+
+See existing namespaces:
+
+​
+kubectl get namespaces
+​
+
+​
+NAME STATUS AGE
+default Active 3d
+kube-system Active 3d
+kube-public Active 3d
+kube-node-lease Active 3d
+​
+
+default is where resources go if you don’t specify a namespace.
+
+kube-system contains system components (DNS, metrics, etc.).
+
+kube-public holds publicly accessible data (rarely used).
+
+kube-node-lease stores node heartbeat data.
+
+​
+
+(Don't worry if this list doesn't match your setup. It can vary
+from cluster to cluster.)
+
+​
+
+Let’s create a namespace for Linkding:
+
+​
+kubectl create namespace linkding
+​
+
+Verify:
+
+​
+kubectl get namespace linkding
+​
+
+​
+NAME STATUS AGE
+linkding Active 5s
+​
+
+Setting Your Default Namespace
+
+Typing -n linkding on every command gets tedious. Let’s set it as
+the default:
+
+​
+kubectl config set-context --current --namespace=linkding
+​
+
+Now commands default to the linkding namespace:
+
+​
+kubectl get pods
+​
+
+​
+No resources found in linkding namespace.
+​
+
+See? It’s looking in linkding, not default.
+
+​
+
+To switch back to default later:
+
+​
+kubectl config set-context --current --namespace=default
+​
+
+But for now, stay in linkding.
+
+​
+
+The Linkding Container Image
+
+Linkding is packaged as a container image available on Docker
+Hub:
+
+​
+sissbruecker/linkding
+​
+
+The image contains a Python web application, a SQLite database
+(by default), and all dependencies pre-installed.
+
+You don’t need to build anything. Just tell Kubernetes to run
+this image.
+
+​
+
+Creating the Deployment YAML
+
+Let’s build our YAML file step by step.
+
+Create a file called linkding.yaml:
+
+​
+
+yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+name: linkding
+namespace: linkding
+labels:
+app: linkding
+spec:
+replicas: 1
+selector:
+matchLabels:
+app: linkding
+template:
+metadata:
+labels:
+app: linkding
+spec:
+containers:
+- name: linkding
+image: sissbruecker/linkding:latest
+ports:
+- containerPort: 9090
+env:
+- name: LD_SUPERUSER_NAME
+value: "admin"
+- name: LD_SUPERUSER_PASSWORD
+value: "changeme123"
+
+Let me explain what’s new here:
+
+namespace: linkding
+
+This deployment lives in the linkding namespace.
+
+replicas: 1
+
+We only need one instance. Linkding uses SQLite by default, which
+doesn’t support multiple writers.
+
+containerPort: 9090
+
+Linkding listens on port 9090 inside the container.
+
+env:
+
+Environment variables passed to the container. Linkding uses
+these to configure the application:
+
+LD_SUPERUSER_NAME sets the admin username.
+
+LD_SUPERUSER_PASSWORD sets the admin password.
+
+Important: In production, you’d never put passwords in plain
+YAML. You’d use Kubernetes Secrets. But for learning, this works.
+
+​
+
+Adding the Service
+
+Add a Service to the same file. Use --- to separate resources:
+
+yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+name: linkding
+namespace: linkding
+labels:
+app: linkding
+spec:
+replicas: 1
+selector:
+matchLabels:
+app: linkding
+template:
+metadata:
+labels:
+app: linkding
+spec:
+containers:
+- name: linkding
+image: sissbruecker/linkding:latest
+ports:
+- containerPort: 9090
+env:
+- name: LD_SUPERUSER_NAME
+value: "admin"
+- name: LD_SUPERUSER_PASSWORD
+value: "changeme123"
+---
+apiVersion: v1
+kind: Service
+metadata:
+name: linkding
+namespace: linkding
+labels:
+app: linkding
+spec:
+selector:
+app: linkding
+ports:
+- port: 9090
+targetPort: 9090
+​
+
+The Service matches pods with app: linkding label, listens on
+port 9090, and forwards to container port 9090.
+
+​
+
+Deploy It
+
+Apply the YAML:
+
+​
+kubectl apply -f linkding.yaml
+​
+
+​
+deployment.apps/linkding created
+service/linkding created
+​
+
+Watch the pod start:
+
+​
+kubectl get pods -w
+​
+
+You’ll see it go from Pending → ContainerCreating → Running.
+
+​
+NAME READY STATUS RESTARTS AGE
+linkding-7d8f9c6b9b-x2kj4 1/1 Running 0 30s
+​
+
+Press Ctrl+C to stop watching.
+
+​
+
+Access Linkding
+
+Port-forward to the service:
+
+​
+kubectl port-forward service/linkding 8080:9090
+​
+
+Open your browser: http://localhost:8080
+
+You should see the Linkding login page.
+
+Log in with username admin and password changeme123.
+
+You’re in.
+
+​
+
+Explore Linkding
+
+Take a few minutes to explore:
+
+* Add a bookmark - Click “Add Bookmark”, paste any URL
+* Add some tags - Organize bookmarks by topic
+* Search - Use the search bar to find bookmarks
+
+Add a few real bookmarks. Kubernetes documentation.. Your
+favorite sites.
+
+​
+
+Checking the Logs
+
+Want to see what Linkding is doing?
+
+​
+kubectl logs deployment/linkding
+​
+
+You’ll see the Django development server output, incoming
+requests, etc.
+
+For live logs:
+
+​
+kubectl logs deployment/linkding -f
+​
+
+Press Ctrl+C to stop.
+
+​
+
+Inspecting the Pod
+
+See full pod details:
+
+​
+kubectl describe pod -l app=linkding
+​
+
+The -l app=linkding selects pods by label instead of by name.
+
+You’ll see the container state, environment variables (including
+your password, which is why Secrets matter), and events (image
+pulled, container started).
+
+​
+
+The Problem We’ll Solve Tomorrow
+
+Try this:
+
+* Stop the port-forward (Ctrl+C)
+* Restart the deployment: ​
+kubectl rollout restart deployment/linkding
+​
+* Wait for the new pod: ​
+kubectl get pods -w
+​
+* Port-forward again: ​
+kubectl port-forward service/linkding 8080:9090
+​
+* Go to http://localhost:8080
+
+​
+
+Try to log in with admin/changeme123.
+
+​
+
+Your bookmarks are gone.
+
+Why? Because containers are ephemeral. When a pod restarts, its
+filesystem is wiped clean.
+
+SQLite stores data in a file inside the container. That file
+disappeared when the container restarted.
+
+This is a critical concept. Containers are stateless by default.
+
+Any data you want to keep must be stored in a Persistent Volume.
+
+Tomorrow, we fix this. You’ll learn about Persistent Volume
+Claims and make your bookmarks survive restarts.
+
+For now, appreciate that you have a real application running on
+Kubernetes.
+
+Not nginx. A bookmark manager you can actually use.
+
+​
+
+What You Learned Today
+
+Namespaces organize resources in your cluster.
+
+kubectl config set-context changes your default namespace.
+
+Environment variables configure containers.
+
+Multiple resources can live in one YAML file with --- separator.
+
+kubectl logs shows container output.
+
+kubectl describe shows detailed resource information.
+
+Containers are ephemeral. Data doesn’t persist by default.
+
+Tomorrow: Persistent storage. Your bookmarks will survive
+anything.
+
+Mischa
+
+​
+
+P.S. Linkding is fun on localhost. But running it with GitOps,
+proper secrets management, TLS certificates, and secure internet
+access? That’s what HomeLab OS covers inside KubeCraft. You’ll
+build a real home lab that impresses interviewers. Not just
+tutorial projects. CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/38u77drlv9hduorlr0pcrh4qgw2nns7h6rqzn/48hvhehmgdpgl0ix/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to get access.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/38u77drlv9hduorlr0pcrh4qgw2nns7h6rqzn
+) | Update your profile (
+https://preferences.convertkit-mail2.com/38u77drlv9hduorlr0pcrh4qgw2nns7h6rqzn
+)

--- a/mvb_k8s/emails/Day-6-Making-your-data-survive-in-Kubernetes.md
+++ b/mvb_k8s/emails/Day-6-Making-your-data-survive-in-Kubernetes.md
@@ -1,0 +1,525 @@
+# Day 6: Making your data survive in Kubernetes
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Sat, 13 Dec 2025 15:28:25 +0000
+
+---
+
+Hey Adam,
+
+Yesterday you saw the problem: restart your pod, lose your data.
+
+Today we fix it with Persistent Volumes.
+
+This is one of the most important concepts in Kubernetes. Every
+real application needs storage: databases, file uploads, user
+data, configuration.
+
+Understanding how storage works separates beginners from people
+who can actually run production workloads.
+
+​
+
+Why Containers Lose Data
+
+When a container starts, it gets a fresh file system from its
+image.
+
+Any changes you make (files created, databases populated, logs
+written) exist only in that container’s writable layer.
+
+When the container stops, that writable layer is discarded. The
+next container starts fresh from the image again.
+
+This is by design. Containers are meant to be disposable.
+
+You should be able to kill a container and start a new one
+without worrying about state.
+
+But applications need to store data somewhere. That’s where
+volumes come in.
+
+​
+
+Volumes in Kubernetes
+
+A Volume is storage that exists outside the container life cycle.
+Data in a volume persists even when containers restart.
+
+Kubernetes has many volume types:
+
+emptyDir provides temporary storage that exists as long as the
+pod exists.
+
+hostPath uses a directory on the node (not recommended for
+production).
+
+persistentVolumeClaim requests storage from the cluster’s storage
+system.
+
+configMap / secret mounts configuration as files.
+
+nfs, awsElasticBlockStore, gcePersistentDisk, azureDisk connect
+to cloud/network storage.
+
+​
+
+For our purposes, we’ll use PersistentVolumeClaim (PVC). This is
+the standard way to request storage in Kubernetes.
+
+​
+
+The Storage Architecture
+
+Kubernetes storage has three components:
+
+​
+
+PersistentVolume (PV) is the actual storage, a piece of disk
+somewhere.
+
+In cloud environments, this might be an AWS EBS volume or Azure
+Disk.
+
+Locally, it’s space on your node’s filesystem.
+
+​
+
+PersistentVolumeClaim (PVC) is a request for storage.
+
+You say “I need 1GB of storage with read-write access” and
+Kubernetes finds or creates a PV to satisfy that claim.
+
+​
+
+StorageClass defines how storage is provisioned.
+
+Different classes might offer different performance, backup
+policies, or underlying storage systems.
+
+​
+
+The flow:
+
+1. You create a PVC requesting storage
+
+2. Kubernetes checks available PVs or dynamically provisions one
+
+3. The PVC binds to a PV
+
+4. Your pod mounts the PVC as a volume
+
+5. Data written to that volume persists across pod restarts
+
+​
+
+Rancher Desktop’s Storage
+
+Rancher Desktop uses K3s, which includes the local-path
+StorageClass.
+
+This automatically provisions storage on your node’s filesystem.
+
+​
+
+Check available storage classes:
+
+​
+kubectl get storageclass
+​
+
+​
+NAME PROVISIONER AGE
+local-path (default) rancher.io/local-path 3d
+​
+
+The (default) means PVCs that don’t specify a storage class will
+use this one.
+
+​
+
+Creating a PersistentVolumeClaim
+
+Let’s update our Linkding deployment to use persistent storage.
+
+First, make sure you’re in the linkding namespace:
+
+​
+kubectl config set-context --current --namespace=linkding
+​
+
+Create a new file called linkding-with-storage.yaml:
+
+yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+name: linkding-data
+namespace: linkding
+spec:
+accessModes:
+- ReadWriteOnce
+resources:
+requests:
+storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+name: linkding
+namespace: linkding
+labels:
+app: linkding
+spec:
+replicas: 1
+selector:
+matchLabels:
+app: linkding
+template:
+metadata:
+labels:
+app: linkding
+spec:
+containers:
+- name: linkding
+image: sissbruecker/linkding:latest
+ports:
+- containerPort: 9090
+env:
+- name: LD_SUPERUSER_NAME
+value: "admin"
+- name: LD_SUPERUSER_PASSWORD
+value: "changeme123"
+volumeMounts:
+- name: linkding-data
+mountPath: /etc/linkding/data
+volumes:
+- name: linkding-data
+persistentVolumeClaim:
+claimName: linkding-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+name: linkding
+namespace: linkding
+labels:
+app: linkding
+spec:
+selector:
+app: linkding
+ports:
+- port: 9090
+targetPort: 9090
+​
+
+Let me explain the new parts:
+
+​
+
+PersistentVolumeClaim:
+
+yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+name: linkding-data
+namespace: linkding
+spec:
+accessModes:
+- ReadWriteOnce
+resources:
+requests:
+storage: 1Gi
+​
+
+name: linkding-data is what we’ll reference in the deployment.
+
+accessModes: ReadWriteOnce means it can be mounted read-write by
+a single node.
+
+storage: 1Gi requests 1 gigabyte of storage.
+
+​
+
+Access modes:
+
+ReadWriteOnce (RWO) allows single node read-write.
+
+ReadOnlyMany (ROX) allows multiple nodes read-only.
+
+ReadWriteMany (RWX) allows multiple nodes read-write (requires
+special storage).
+
+​
+
+volumeMounts in the container:
+
+yaml
+volumeMounts:
+- name: linkding-data
+mountPath: /etc/linkding/data
+​
+
+This mounts the volume named linkding-data at /etc/linkding/data
+inside the container.
+
+Linkding stores its SQLite database in /etc/linkding/data.
+
+By mounting our persistent volume there, the database persists
+across restarts.
+
+​
+
+volumes in the pod spec:
+
+yaml
+volumes:
+- name: linkding-data
+persistentVolumeClaim:
+claimName: linkding-data
+​
+
+This creates a volume from our PVC. The name linkding-data
+matches what we referenced in volumeMounts.
+
+​
+
+Deploy the Updated Version
+
+Delete the old deployment and apply the new one:
+
+​
+kubectl delete -f linkding.yaml
+kubectl apply -f linkding-with-storage.yaml
+​
+
+​
+persistentvolumeclaim/linkding-data created
+deployment.apps/linkding created
+service/linkding unchanged
+​
+
+Check the PVC:
+
+​
+kubectl get pvc
+​
+
+​
+NAME STATUS VOLUME
+CAPACITY ACCESS MODES
+linkding-data Bound pvc-a1b2c3d4-e5f6-7890-abcd-ef1234567890
+1Gi RWO
+​
+
+STATUS: Bound means the PVC has been bound to a PersistentVolume.
+Storage is ready.
+
+Check the pod:
+
+​
+kubectl get pods
+​
+
+Wait for it to be Running.
+
+​
+
+Test the Persistence
+
+Port-forward:
+
+​
+kubectl port-forward service/linkding 8080:9090
+​
+
+Go to http://localhost:8080 and log in (admin/changeme123).
+
+Add some bookmarks. At least 3-4 that you’d actually want to
+keep.
+
+Now the test:
+
+* Stop port-forward (Ctrl+C)
+* Restart the deployment: ​
+kubectl rollout restart deployment/linkding
+​
+* Watch the pod restart: ​
+kubectl get pods -w
+​
+* Wait for the new pod to be Running, then Ctrl+C
+* Port-forward again: ​
+kubectl port-forward service/linkding 8080:9090
+​
+* Go to http://localhost:8080
+
+​
+
+Log in. Your bookmarks are still there.
+
+​
+
+The pod was destroyed and recreated. A completely new container
+started. But your data persisted because it lives in the
+PersistentVolume, not the container.
+
+​
+
+Inspecting the Storage
+
+See the PersistentVolume that was created:
+
+​
+kubectl get pv
+​
+
+​
+NAME CAPACITY ACCESS
+MODES RECLAIM POLICY STATUS CLAIM
+pvc-a1b2c3d4-e5f6-7890-abcd-ef1234567890 1Gi RWO
+Delete Bound linkding/linkding-data
+​
+
+RECLAIM POLICY: Delete means when the PVC is deleted, the PV is
+also deleted.
+
+STATUS: Bound means it’s currently bound to a PVC.
+
+CLAIM: linkding/linkding-data shows the PVC using this PV.
+
+​
+
+Describe the PVC for more details:
+
+​
+kubectl describe pvc linkding-data
+​
+
+You’ll see the storage class, the bound volume, and mount
+information.
+
+​
+
+Looking Inside the Container
+
+Let’s see where the data actually lives:
+
+​
+kubectl exec -it deployment/linkding -- /bin/sh
+​
+
+You’re now inside the container. Look at the data directory:
+
+​
+ls -la /etc/linkding/data
+​
+
+​
+total 184
+drwxr-xr-x 2 root root 4096 Nov 25 12:00 .
+drwxr-xr-x 1 root root 4096 Nov 25 11:00 ..
+-rw-r--r-- 1 root root 176128 Nov 25 12:05
+db.sqlite3
+​
+
+There’s the SQLite database. This file lives on the
+PersistentVolume.
+
+Exit the container:
+
+​
+exit
+​
+
+Understanding What Happened
+
+Let’s trace the full flow:
+
+* We created a PVC requesting 1Gi of storage
+* The local-path StorageClass provisioned a PersistentVolume on
+the node
+* The PVC bound to that PV
+* Our deployment referenced the PVC in its volumes
+* The container mounted the volume at /etc/linkding/data
+* Linkding wrote its database to that path
+* When the pod restarted, the new container mounted the same
+volume
+* The database was still there
+
+This is how every stateful application works in Kubernetes:
+databases, file servers, message queues. The pattern is always
+the same.
+
+​
+
+Storage in Production
+
+In production Kubernetes:
+
+Cloud storage includes AWS EBS, Azure Disk, GCP Persistent Disk.
+
+Network storage includes NFS, Ceph, GlusterFS.
+
+Storage operators include Rook, OpenEBS, Longhorn.
+
+​
+
+You’d have multiple StorageClasses for different needs: fast SSD
+storage for databases, cheap HDD storage for backups, replicated
+storage for high availability.
+
+The application doesn’t care. It just requests a PVC, and the
+cluster provides storage.
+
+​
+
+What You Learned Today
+
+Containers are ephemeral. Data doesn’t persist by default.
+
+PersistentVolume (PV) is actual storage provisioned in the
+cluster.
+
+PersistentVolumeClaim (PVC) is a request for storage.
+
+StorageClass defines how storage is provisioned.
+
+volumeMounts defines where to mount storage inside the container.
+
+volumes connects pods to PVCs.
+
+Data survives restarts because it lives outside the container.
+
+​
+
+Your Capstone Project is Complete
+
+You now have a real application running on Kubernetes, organized
+in its own namespace, with persistent storage, accessible via
+port forward.
+
+This is more than most “Kubernetes tutorials” teach. You’ve
+actually built something useful.
+
+Tomorrow, we wrap up and talk about what comes next.
+
+Mischa
+
+​
+
+P.S. You built something real. But it’s still on your laptop with
+port-forwarding. Inside KubeCraft, HomeLab OS teaches you to run
+this 24/7 on dedicated hardware, expose it to the internet
+securely with TLS certificates, set up automatic backups, and
+manage it with GitOps. That’s the difference between a tutorial
+project and production-ready infrastructure. CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/d0uqqkp5zncmu4kgk9dtmhzl7d544ilhonw5m/dpheh0he5l4oqpim/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) if you want those real production skills.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/d0uqqkp5zncmu4kgk9dtmhzl7d544ilhonw5m
+) | Update your profile (
+https://preferences.convertkit-mail2.com/d0uqqkp5zncmu4kgk9dtmhzl7d544ilhonw5m
+)

--- a/mvb_k8s/emails/Decision-Time-Do-You-Want-a-6-figure-DevOps-job.md
+++ b/mvb_k8s/emails/Decision-Time-Do-You-Want-a-6-figure-DevOps-job.md
@@ -1,0 +1,265 @@
+# Decision Time: Do You Want a 6-figure DevOps job?
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Mon, 15 Dec 2025 15:29:51 +0000
+
+---
+
+Hey Adam,
+
+This is the last email of the course.
+
+I want to be real with you.
+
+Most people who start learning Kubernetes never finish.
+
+They watch a few videos. They follow a tutorial.
+
+They feel good for a day. Then life gets busy.
+
+Netflix is easier than kubectl. They quit.
+
+A few months later, they see a job posting:
+
+“DevOps Engineer - $150K - Remote - Kubernetes Required”
+
+And they feel that familiar pang of regret. “I should have stuck
+with it.”
+
+​
+
+You’re Different
+
+You made it through 7 days. You didn’t just read - you built.
+
+You have a real application running on Kubernetes with persistent
+storage.
+
+That puts you ahead of 90% of people who “learn Kubernetes.”
+
+​
+
+But I’ve seen this movie too many times:
+
+Someone finishes a course. Feels motivated. Plans to keep
+learning.
+
+Then a week passes. Then a month. Then six months.
+
+They’re still watching tutorials. Still “learning.” Still no job.
+Still stuck.
+
+​
+
+I Don’t Want That For You
+
+Here’s what I know after helping over 1,000 people land DevOps
+jobs:
+
+The ones who succeed aren’t smarter. They don’t have more time.
+They don’t have better connections.
+
+They have three things:
+
+​
+
+1. A Proven System
+
+Not random YouTube videos. Not “just build projects.” A
+structured path with clear milestones.
+
+DevOps OS teaches the full stack: Linux, networking, containers,
+Kubernetes, CI/CD, cloud. Everything you need, in the right
+order.
+
+HomeLab OS has you build an enterprise-grade home lab on real
+hardware. GitOps deployments. Secure ingress. Automatic backups.
+The kind of infrastructure that impresses interviewers.
+
+Job Magnet OS transforms your GitHub and LinkedIn into a DevOps
+job magnet. Recruiters reach out to you instead of you applying
+to hundreds of jobs.
+
+Interview OS prepares you for technical and behavioral
+interviews. Not just “common questions.” Actual practice with
+feedback.
+
+​
+
+2. Real Proof
+
+Anyone can claim “Kubernetes experience” on LinkedIn.
+
+KubeCraft students have working infrastructure they can demo in
+interviews.
+
+GitHub profiles with real infrastructure projects.
+
+LinkedIn profiles that attract recruiters.
+
+Stories about problems they’ve solved.
+
+When an interviewer asks “tell me about your experience,” they
+have answers that stand out.
+
+​
+
+3. Community and Mentorship
+
+Learning alone is slow and frustrating. You get stuck. You go
+down rabbit holes. You don’t know if you’re on the right track.
+
+Inside KubeCraft:
+
+800+ engineers at all stages. People just starting. People who
+just got hired. People with years of experience. Ask questions
+and get answers in hours, not days of Googling.
+
+3x weekly live coaching calls. Bring your questions. Share your
+screen. Get unstuck in real-time. Direct access to me and other
+industry experts.
+
+Accountability. When motivation dips - and it will - the
+community keeps you moving.
+
+​
+
+The Results
+
+Over 1,000 people have used this system to land DevOps roles.
+
+In 2 to 20 weeks.
+
+At companies like Google, Microsoft, Amazon, Nvidia, and hundreds
+of others.
+
+Nurses who became DevOps engineers. Teachers who escaped
+education. Retail workers who knew they could do more. Junior
+developers who broke through to senior roles. Career changers in
+their 30s, 40s, 50s.
+
+Most of them got jobs without mass-applying like everyone else.
+They got inbound interest because their profiles stood out.
+Because they had proof. Because they were visible.
+
+​
+
+What You Get
+
+60+ hours of video courses teaching production-grade projects.
+Not theory. Real deployments, real infrastructure, real skills
+that employers want.
+
+HomeLab OS. Build an enterprise-grade home lab from scratch.
+GitOps, secure ingress, TLS certificates, automated backups. The
+kind of portfolio piece that wins interviews.
+
+JobMagnet OS. Turn your GitHub and LinkedIn into a DevOps job
+magnet. Stop applying into the void. Start getting recruiters
+reaching out to you.
+
+Interview OS. Technical and behavioral prep that turns
+conversations into offers. Practice the actual skills
+interviewers are looking for.
+
+3x weekly live coaching. Direct access to me and other industry
+experts. Bring questions. Share your screen. Get unstuck.
+
+Community of 800+ engineers. 24/7 support. Job referrals.
+Accountability. People who’ve been where you are and made it to
+the other side.
+
+​
+
+​
+
+​
+​
+
+My guarantee:
+
+If you put in the work and follow the system, you will land
+DevOps job interviews.
+
+Not in a year. In weeks to months.
+
+I did it. Over a thousand of my students have done it. You can
+too.
+
+The system works so well, that I give the following guarantee:
+
+We will work with you for free until you land the interviews.
+
+​
+
+The Math
+
+The average Kubernetes salary is $170,000/year.
+
+Every month you spend “learning” without a job costs you roughly
+$14,000.
+
+I spent a year figuring this out alone. That’s $168,000 I left on
+the table.
+
+My students don’t make that mistake.
+
+​
+
+This Is Your Decision Point
+
+You’ve learned a lot this week. You have real skills now.
+
+But a 7-day email course isn’t going to get you hired.
+
+The question is: what happens next?
+
+​
+
+Option 1: Go back to your regular routine. Watch some more
+YouTube. “Keep learning.” Maybe get there eventually. Maybe not.
+
+​
+
+Option 2: Join a proven system. Get structure, community, and
+mentorship. Land a DevOps job in weeks to months instead of
+years.
+
+​
+
+I’m opening a few spots for new members this month.
+
+If you’re serious about making this transition (not just
+“interested,” but ready to put in the work), I’d love to help
+you.
+
+​CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/75u55z3wgdc2uk87pveizhwe8n966bnh5oxrl/25h2hoh3dmmewrs3/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+)to apply and see if you qualify.
+
+This is your decision point.
+
+Let’s build the career you actually want.
+
+Mischa
+
+​
+
+P.S. Every month you wait costs you $10,000+ in lost earning
+potential. While you’re watching tutorials, others are landing
+$150K+ remote DevOps roles. A year from now, you’ll wish you
+started today. I know because I wasted that year myself. Don’t
+repeat my mistake. CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/75u55z3wgdc2uk87pveizhwe8n966bnh5oxrl/25h2hoh3dmmewrs3/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to apply now.
+
+​
+
+​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/75u55z3wgdc2uk87pveizhwe8n966bnh5oxrl
+) | Update your profile (
+https://preferences.convertkit-mail2.com/75u55z3wgdc2uk87pveizhwe8n966bnh5oxrl
+)

--- a/mvb_k8s/emails/Did-you-see-it-happen.md
+++ b/mvb_k8s/emails/Did-you-see-it-happen.md
@@ -1,0 +1,120 @@
+# Did you see it happen?
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Tue, 09 Dec 2025 19:32:41 +0000
+
+---
+
+Hey Adam,
+
+​
+
+Quick check-in.
+
+Did you watch Kubernetes self-heal when you deleted that pod?
+
+That moment where you break something and watch the system fix
+itself in seconds is when Kubernetes clicks for most people.
+
+It’s not magic. It’s a control loop. Constantly watching.
+Constantly reconciling.
+
+This is why companies trust Kubernetes with production workloads.
+Not because engineers are watching dashboards 24/7, but because
+the system maintains itself.
+
+​
+
+If you got stuck, here’s help:
+
+“kubectl get pods shows no pods”
+
+​
+
+You might have accidentally deleted the deployment. Recreate it:
+​
+kubectl create deployment my-app --image=nginx --replicas=3
+​
+
+“command not found: kubectl”
+
+Rancher Desktop needs to configure your PATH. Open Rancher
+Desktop → Preferences → Application → Path → set to Automatic.
+Then restart your terminal completely (not just open a new tab).
+
+​
+
+“Pods stuck in Pending”
+
+Your cluster might be resource-constrained. Check node status: ​
+kubectl describe node rancher-desktop
+​
+
+Look at “Allocatable” vs “Allocated resources.” If you’re near
+the limits, go to Rancher Desktop → Preferences → Virtual Machine
+and increase memory/CPU.
+
+​
+
+“Pods in CrashLoopBackOff”
+
+The container is crashing. Check logs: ​
+kubectl logs
+​
+
+If it’s an nginx pod, this shouldn’t happen. Try deleting the
+deployment and recreating it.
+
+​
+
+“ImagePullBackOff”
+
+Kubernetes can’t download the container image. This usually
+means: 1. Typo in the image name 2. No internet connection 3.
+Docker Hub rate limiting (rare for nginx)
+
+Check the image name is exactly nginx (not ngnix or
+nginx:lastest).
+
+​
+
+What’s Coming Tomorrow
+
+Your deployment is running. But right now, those pods are
+isolated. They have internal IP addresses that change every time
+a pod restarts.
+
+How do you actually connect to them? How do you access nginx in
+your browser?
+
+Tomorrow: Services - the networking layer that makes everything
+work.
+
+Make sure your deployment is still running: ​
+kubectl get deployment my-app
+​
+
+If you see READY 3/3 (or 2/2, whatever you scaled to), you’re
+good.
+
+Talk soon,
+
+Mischa
+
+​
+
+P.S. Most people quit when they hit their first error. They
+Google for hours, get frustrated, and give up. Inside KubeCraft,
+you get coaching calls where I answer questions live and daily
+support from me and my team. You share your screen, I see your
+error, we fix it together. No more getting stuck alone. CLICK
+HERE (
+https://ed9688f7.click.convertkit-mail2.com/wvuddk0xpeh6u54p4x6s7hnqg79xxb8h4qm2e/kkhmh6hnmwlvrzil/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) if you want my direct mentorship.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/wvuddk0xpeh6u54p4x6s7hnqg79xxb8h4qm2e
+) | Update your profile (
+https://preferences.convertkit-mail2.com/wvuddk0xpeh6u54p4x6s7hnqg79xxb8h4qm2e
+)

--- a/mvb_k8s/emails/He-landed-a-Kubernetes-job-in-2-weeks.md
+++ b/mvb_k8s/emails/He-landed-a-Kubernetes-job-in-2-weeks.md
@@ -1,0 +1,57 @@
+# He landed a Kubernetes job in 2 weeks
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Wed, 10 Dec 2025 19:33:25 +0000
+
+---
+
+​
+​
+
+Hey Adam,
+
+Quick story.
+
+Lennard joined KubeCraft with zero Kubernetes experience.
+
+He had the same problem you probably have: he’d been learning for
+months but getting nowhere with job applications.
+
+I looked at his situation and immediately saw the gaps.
+
+His LinkedIn was generic. His GitHub was empty.
+
+He had no way to demonstrate experience. And his network was
+non-existent.
+
+He joined KubeCraft (
+https://ed9688f7.click.convertkit-mail2.com/4zu33el4x8c7u594804bxh6kznv77f5h6mq42/48hvhehmg8rr8nfx/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) and started learning Kubernetes and working on his LinkedIn.
+
+2 weeks later, job offer.
+
+Not because Lennard was special.
+
+Because he addressed the gaps most people ignore.
+
+Tomorrow we'll learn how to deploy applications to Kubernetes the
+proper way.
+
+Talk then,
+
+Mischa
+
+​
+
+P.S. Lennard isn’t an outlier. This is what happens when you stop
+learning randomly and get mentored by experts. If you want the
+same kind of personalized analysis, book a call with my team. (
+https://ed9688f7.click.convertkit-mail2.com/4zu33el4x8c7u594804bxh6kznv77f5h6mq42/48hvhehmg8rr8nfx/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+)​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/4zu33el4x8c7u594804bxh6kznv77f5h6mq42
+) | Update your profile (
+https://preferences.convertkit-mail2.com/4zu33el4x8c7u594804bxh6kznv77f5h6mq42
+)

--- a/mvb_k8s/emails/How-To-Land-A-Kubernetes-Job-That-Pays-171K.md
+++ b/mvb_k8s/emails/How-To-Land-A-Kubernetes-Job-That-Pays-171K.md
@@ -1,0 +1,282 @@
+# How To Land A Kubernetes Job That Pays $171K
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Sun, 14 Dec 2025 15:29:15 +0000
+
+---
+
+Hey Adam,
+
+You made it.
+
+7 days. Real hands-on Kubernetes experience. A working
+application with persistent storage.
+
+Let me show you what you actually learned:
+
+​
+
+The Fundamentals
+
+Kubernetes architecture. Control plane, worker nodes, how they
+communicate.
+
+Pods. The smallest deployable unit, wrapper around containers.
+
+Deployments. Declarative management, replicas, self-healing.
+
+Services. Stable endpoints, load balancing, service discovery.
+
+Namespaces. Organizing and isolating resources.
+
+Persistent Volumes. Storage that survives container restarts.
+
+YAML manifests. Infrastructure as code.
+
+kubectl. The command-line tool for everything.
+
+​
+
+You understand more than most people who put “Kubernetes” on
+their LinkedIn.
+
+​
+
+But Let’s Be Honest
+
+This is the beginner stuff.
+
+Real Kubernetes jobs require more:
+
+​
+
+Networking:
+
+Ingress controllers for HTTP routing.
+
+TLS certificates and HTTPS.
+
+Network policies for security.
+
+DNS configuration.
+
+Load balancer integration.
+
+​
+
+Configuration & Secrets:
+
+ConfigMaps for configuration data.
+
+Secrets for sensitive information.
+
+Environment variables vs. mounted files.
+
+External secret managers (Vault, AWS Secrets Manager).
+
+​
+
+Observability:
+
+Prometheus for metrics.
+
+Grafana for dashboards.
+
+Log aggregation (Loki, ELK stack).
+
+Alerting and on-call.
+
+​
+
+CI/CD & GitOps:
+
+Deploying from Git, not from kubectl.
+
+ArgoCD, Flux.
+
+Automated testing and deployment.
+
+Rolling updates and rollbacks.
+
+​
+
+Security:
+
+RBAC (Role-Based Access Control).
+
+Pod security standards.
+
+Network policies.
+
+Image scanning.
+
+Compliance and auditing.
+
+​
+
+Cluster Operations:
+
+Upgrading Kubernetes versions.
+
+Node management.
+
+Resource quotas and limits.
+
+Disaster recovery.
+
+​
+
+This list isn’t meant to overwhelm you. It’s meant to show you
+the full picture.
+
+​
+
+The Gap
+
+​
+
+There’s a gap between “I did a Kubernetes tutorial” and “I can
+get hired as a Kubernetes engineer.”
+
+Most people get stuck in that gap.
+
+​
+
+They watch more tutorials. They “learn” for months or years.
+
+They never feel ready to apply. They never build anything real.
+They never get the job.
+
+​
+
+I was stuck in that gap for a year.
+
+​
+
+I watched hundreds of hours of content. I knew a lot of theory.
+
+But I couldn’t troubleshoot a failing cluster under pressure. I
+didn’t have projects to show. My GitHub was empty.
+
+​
+
+Then I built a home lab. I broke things at 11pm with no
+consequences. I deployed real applications. I fixed real
+problems.
+
+That’s when Kubernetes clicked.
+
+​
+
+What Separates the Top 10%
+
+​
+
+The people who actually land Kubernetes jobs do three things
+differently:
+
+1. They build proof
+
+Not tutorials. Projects with real infrastructure. A GitHub
+profile with actual meaningful code. A portfolio that shows they
+can do the work.
+
+When an interviewer asks “tell me about a Kubernetes project,”
+they have real answers.
+
+Not “I followed a tutorial.” Real applications they deployed,
+problems they solved, decisions they made.
+
+​
+
+​
+2. They get get approached by recruiters
+
+A profile optimized for DevOps keywords. Recruiters finding them
+instead of them applying to hundreds of jobs.
+
+90% of people apply like everyone else. They send resumes into
+the void. They hear nothing back.
+
+The top 10% get inbound interest because they’re visible. Because
+they have proof. Because their profiles stand out.
+
+​
+
+​
+3. They have support
+
+They don’t learn alone. They have mentors who’ve done it before.
+Communities where they can ask questions. People who push them
+when motivation dips.
+
+Learning alone, you waste time on the wrong things. You get stuck
+for days on problems someone could solve in minutes. You don’t
+know if you’re on the right track.
+
+With support, you move faster. You avoid the rabbit holes. You
+know when you’re ready.
+
+​
+
+​
+​
+
+The Path Forward
+
+You have two options:
+
+Option 1: Continue on your own
+
+Keep learning from free resources. Watch more tutorials.
+
+Build projects alone. Figure out what to learn next. Hope you’re
+on the right track.
+
+This works for some people. It took me a year, but I eventually
+got there.
+
+​
+
+Option 2: Join KubeCraft
+
+Get a proven system. 60+ hours of production-grade projects.
+
+A home lab course that builds real infrastructure.
+
+Job prep that actually works.
+
+Join 800+ engineers who are on the same path.
+
+Ask questions and get answers in hours.
+
+Have direct mentorship calls where you can get unstuck.
+
+Have me guide you through the process.
+
+The same process I’ve used to help over 1,000 people land DevOps
+roles in 2 to 20 weeks.
+
+I’ll send one more email with the full details.
+
+Mischa
+
+​
+
+P.S. I’ve helped nurses, teachers, retail workers, junior devs,
+and senior engineers make this transition. They’ve landed at
+Google, Microsoft, Nvidia, and hundreds of other companies. If
+you’re serious about being next, CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/n4uzz385kgbqu8gp5wra6h68xz5ggflhg7pqx/8ghqhoho9rek75sk/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to apply.
+
+​
+
+​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/n4uzz385kgbqu8gp5wra6h68xz5ggflhg7pqx
+) | Update your profile (
+https://preferences.convertkit-mail2.com/n4uzz385kgbqu8gp5wra6h68xz5ggflhg7pqx
+)

--- a/mvb_k8s/emails/How-are-you-feeling.md
+++ b/mvb_k8s/emails/How-are-you-feeling.md
@@ -1,0 +1,155 @@
+# How are you feeling?
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Sat, 13 Dec 2025 19:31:01 +0000
+
+---
+
+Hey Adam,
+
+​
+
+6 days in.
+
+You’ve gone from zero Kubernetes knowledge to running a real
+application with persistent storage.
+
+Let me recap what you’ve learned:
+
+Day 1: Installed Rancher Desktop, understood clusters and pods,
+deployed nginx
+
+Day 2: Created deployments, watched self-healing, scaled replicas
+up and down
+
+Day 3: Exposed pods with services, used port-forward, understood
+ClusterIP and NodePort
+
+Day 4: Wrote YAML manifests, learned declarative configuration,
+used –dry-run
+
+Day 5: Created namespaces, deployed Linkding, configured
+environment variables
+
+Day 6: Added persistent storage, made data survive restarts
+
+​
+
+That’s a lot. More than most people learn in weeks of casual
+YouTube watching.
+
+​
+
+How are you feeling?
+
+Excited about what you’ve built?
+
+Or maybe overwhelmed by how much there still is to learn?
+
+Both are valid.
+
+Here’s what I know after teaching 1,000+ people:
+
+The overwhelm is normal. Kubernetes is huge.
+
+The CNCF landscape has hundreds of projects.
+
+You could spend years learning and still not know everything.
+
+​
+
+But here’s the thing: you don’t need to know everything.
+
+To land a Kubernetes job, you need to:
+
+* Understand core concepts (pods, deployments, services, storage)
+✓
+* Deploy and troubleshoot applications
+* Work with YAML and kubectl confidently in troubleshooting
+situations
+* Have experience with GitOps
+* Have projects to show in interviews
+* Know enough about related topics (Linux, networking, CI/CD)
+
+​
+
+You’ve already made real progress on that list.
+
+What Separates People Who Get Hired
+
+The people who successfully transition to DevOps careers aren’t
+smarter than you.
+
+They don’t have more time.
+
+They have:
+
+​
+
+1. A structured path
+
+Not random tutorials.
+
+A clear sequence of what to learn and when.
+
+Knowing the difference between “nice to know” and “need to know.”
+
+​
+
+2. Real projects
+
+Not just following tutorials, but building things they can show
+in interviews.
+
+A home lab. GitHub repositories. Proof that they can do the work.
+
+​
+
+3. Accountability and support
+
+Someone to answer questions. To review their work.
+
+To push them when motivation dips. To tell them when they’re
+ready to apply.
+
+The knowledge is out there for free. Structure and support are
+what most people lack.
+
+​
+
+Tomorrow Is the Last Day
+
+I’ll share what you learned this week (the full picture), what’s
+still ahead on the path to a Kubernetes job, and how I can help
+if you’re serious about making this transition.
+
+For now, take a moment to appreciate what you’ve built.
+
+A week ago, Kubernetes was a mystery.
+
+Now you have a self-hosted application running with persistent
+storage. That’s real.
+
+Talk soon,
+
+Mischa
+
+​
+
+P.S. If you’re feeling excited but also overwhelmed, that’s
+exactly how I felt when I started. I spent a year going in
+circles, learning the wrong things in the wrong order. You don’t
+have to repeat my mistakes. Inside KubeCraft, you get a proven
+system, direct mentorship, weekly coaching calls, and a community
+of 800+ engineers who’ve been where you are. CLICK HERE (
+https://ed9688f7.click.convertkit-mail2.com/xmu99l4v20c3urz6d8pi5h2qxgkllinhpvq23/08hwh9h2z375p5sl/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to apply.
+
+​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://ed9688f7.unsubscribe.convertkit-mail2.com/xmu99l4v20c3urz6d8pi5h2qxgkllinhpvq23
+) | Update your profile (
+https://preferences.convertkit-mail2.com/xmu99l4v20c3urz6d8pi5h2qxgkllinhpvq23
+)

--- a/mvb_k8s/emails/Re-IMPORTANT-Do-this-to-receive-the-rest-of-your-course.md
+++ b/mvb_k8s/emails/Re-IMPORTANT-Do-this-to-receive-the-rest-of-your-course.md
@@ -1,0 +1,51 @@
+# Re: IMPORTANT! Do this to receive the rest of your course.
+
+**From:** (reply to KubeCraft)  
+**Date:** Mon, 08 Dec 2025 15:45:25 -0600
+
+---
+
+*READY*
+
+On Mon, Dec 8, 2025 at 3:32 PM Mischa van den Burg <news@kubecraft.dev>
+wrote:
+
+> Hey Adam,
+>
+> Before tomorrow’s email lands, I need you to do something.
+>
+> *Reply to this email with the word “READY”.*
+>
+> Just that one word. Or a few random characters.
+>
+> Here’s why:
+>
+> Email providers like Gmail watch for engagement. If you don’t reply, the
+> emails could go to spam.
+>
+> And tomorrow’s email contains the an extensive module about Deployments,
+> you don’t want to miss it.
+>
+> So hit reply. Type “READY.” Send.
+>
+> Takes 10 seconds.
+>
+> ​
+>
+> If you’re using Gmail, drag this email to your Primary tab. That tells
+> Google you want to receive these.
+>
+> ​
+>
+> Talk tomorrow,
+>
+> Mischa
+>
+> ​
+> ​
+>
+> 113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe
+> <https://unsubscribe.convertkit-mail2.com/92u77x3wg4hduqxorgrt9hzolw633iwhz9pnd>
+> | Update your profile
+> <https://preferences.convertkit-mail2.com/92u77x3wg4hduqxorgrt9hzolw633iwhz9pnd>
+>

--- a/mvb_k8s/emails/Running-these-apps-in-my-homelab-made-me-600K.md
+++ b/mvb_k8s/emails/Running-these-apps-in-my-homelab-made-me-600K.md
@@ -1,0 +1,264 @@
+# Running these apps in my homelab made me $600K
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Mon, 01 Dec 2025 18:40:21 +0000
+
+---
+
+Hey Adam,
+
+​
+
+One of the questions I get often is: so I built my home lab. What
+do I do with it?
+
+And it’s one of my favorite questions to answer.
+
+Every week I host several live Q&A calls in KubeCraft (
+https://click.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx/6qheh8hlolm3p9co/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svYTI5ZTc2
+).
+
+And this question comes up regularly.
+
+During these mentorship sessions, I teach my students a process
+that you won't find anywhere else.
+
+So instead of just giving you a list of apps to run, I’ll share
+my whole thought process so you can decide for yourself.
+
+I think that will serve you better than a list of apps.
+
+​
+
+But before we jump in, I should let you know that I'm only
+accepting 10 new students in December.
+
+If you want to get direct mentorship from me, CLICK HERE (
+https://click.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx/6qheh8hlolm3p9co/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svYTI5ZTc2
+) to claim your spot.
+
+I'll help you land a remote, 6-figure DevOps job so you can live
+the life of your dreams.
+
+​
+
+--------------------------
+What is a home lab anyway?
+--------------------------
+
+First of all, let’s think about what a home lab is.
+
+One big misconception people have is that home labs need to be
+big server racks with thousands of dollars of equipment.
+
+They think you need to run 5 node Kubernetes clusters before you
+can even call it a home lab.
+
+This is completely false.
+
+My home lab started with a ThinkPad T430. An old laptop that was
+gathering dust in a closet.
+
+I installed Linux on there, and ran Linkding in a Docker
+container.
+
+I was so proud. I had my own little application that I could run.
+
+I was self-hosting. And it all started from there.
+
+​
+
+-------------------------------
+Solve Problems You Already Have
+-------------------------------
+
+When I get the question, “what should I run?”, my first reaction
+is always to solve problems you already have in your life.
+
+The reason why I ended up self-hosting Linkding was because I was
+switching browsers so often.
+
+I would sometimes have three different browsers running.
+
+One on my phone, one on my laptop, and one on my main
+workstation.
+
+I needed a place to store my bookmarks that was independent of
+the browser.
+
+And after using Raindrop for a while, I somehow discovered
+Linkding.
+
+I’ve been using it for over 3 years now.
+
+So here’s what I encourage you to do:
+
+Try to think of something that you find yourself doing
+repeatedly.
+
+A chore that keeps coming back and that you don’t like doing.
+
+Then find a way to automate that.
+
+For example, you can automate the dimming of lights using Home
+Assistant.
+
+One friend of mine scrapes the current prices of power, and
+calculates whether he should run his laundry machine in the
+morning or in the evening.
+
+Everybody has different problems. So I can't tell you which one
+to pick.
+
+But here's one of the main problems I fixed for myself:
+
+------------
+Storing Data
+------------
+
+The second main use-case I have for my own home lab is to store
+data.
+
+I’m a fond user of all sorts of tracking devices.
+
+I use both WHOOP and and Oura ring to track my sleep and other
+health metrics.
+
+I track all the calories I eat in in Macrofactor.
+
+(Though I am not perfect and I do have weeks where I slack on
+this)
+
+I also weigh myself every morning.
+
+All of these devices are generating data that’s being stored by
+other companies.
+
+I can access the data from their portals and apps, but I don’t
+really own that data.
+
+This was bothering me to no end, so I decided to create my own
+services that extract the data from these applications and store
+them in my own databases.
+
+I had a problem that I wanted to solve.
+
+But one other thing that plays a role in my home lab decision
+making process is whether something has relevance for my
+development as an engineer.
+
+At the time I was working for a company that used the EDB
+operator (
+https://click.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx/kkhmh6hnmnko8ocl/aHR0cHM6Ly93d3cuZW50ZXJwcmlzZWRiLmNvbQ==
+) to run Postgres databases on Kubernetes.
+
+I wanted to learn more about Kubernetes database operations.
+
+I decided to combine my desire to store my tracker data with my
+interest in running databases and interacting with them from
+code.
+
+After a weekend of tinkering I had a scraper that would grab all
+of my Oura data and store it in a postgres database.
+
+And the best part was that I could visualize it with Grafana
+dashboards!
+
+​
+
+​
+As a side note, I actually used to do this from my self-hosted
+n8n instance, but Oura recently made a change.
+
+They won’t allow you to authenticate with PAT tokens anymore, so
+I had to create a new applications that authorizes with an Oauth2
+flow.
+
+If you’re interested you can view the source code here:
+
+​https://github.com/mischavandenburg/oura-scraper (
+https://click.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx/25h2hoh3d3kq75i3/aHR0cHM6Ly9naXRodWIuY29tL21pc2NoYXZhbmRlbmJ1cmcvb3VyYS1zY3JhcGVy
+)​
+
+​
+
+--------
+The Goal
+--------
+
+The main goal of the home lab is to have a place where you can
+experiment and develop yourself.
+
+But to what end do you do this? Is it only for fun?
+
+I already alluded to it earlier in this newsletter, but the home
+lab is much more than a place to learn tech.
+
+It’s your personal portfolio to land remote 6 figure DevOps jobs.
+
+Because that’s why you’re here right?
+
+You want to work where you want, with the people you want, on the
+people you want.
+
+The home lab is what hundreds of my students have done to land
+these kinds of jobs.
+
+Some times within a couple of weeks!
+
+​
+
+​
+​
+
+​
+
+When you join KubeCraft, you get a complete system that will
+teach you to become a DevOps engineer from scratch.
+
+One of these systems is called Homelab OS.
+
+This is an extremely deep course that will take you from zero
+Kubernetes knowledge to building a public homelab that acts as an
+irresistible portfolio project.
+
+Home labs are fun, and a great hobby to practice.
+
+But if you want a remote 6-figure DevOps job, you have to stop
+playing around and start taking action.
+
+​CLICK HERE (
+https://click.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx/6qheh8hlolm3p9co/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svYTI5ZTc2
+) to get access to Homelab OS and to start making $171K+ a year.
+
+​
+
+​
+
+Take the teachings from this newsletter and use them to find home
+lab use cases that make your life better.
+
+It is the most satisfying hobby I have ever started, and I’m not
+going to stop any time soon.
+
+Keep striving for that remote job and complete autonomy,
+
+Mischa
+
+​
+
+P.S. We are only accepting 10 students for the December cohort.
+CLICK HERE (
+https://click.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx/6qheh8hlolm3p9co/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svYTI5ZTc2
+) to claim your spot before they run out.
+
+​
+
+​
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://unsubscribe.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx
+) | Update your profile (
+https://preferences.convertkit-mail2.com/n4uzz385kgbvhxew6qnt6h68xz5ggflhg7pqx
+)

--- a/mvb_k8s/emails/You-asked-I-built-it.md
+++ b/mvb_k8s/emails/You-asked-I-built-it.md
@@ -1,0 +1,64 @@
+# You asked, I built it
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Mon, 08 Dec 2025 19:15:06 +0000
+
+---
+
+Hey Adam,
+
+I've been posting a lot about Kubernetes recently.
+
+For example in this previous newsletter (
+https://click.convertkit-mail2.com/8kuxxp309muoh2k5z53ikhk680599b3hom0k6/qvh8h7hdnprgm2cl/aHR0cHM6Ly9sZXR0ZXJzLmt1YmVjcmFmdC5kZXYvcG9zdHMvc29jaWFsLW1lZGlhLWxpZWQtaGVyZS1zLXdoYXQtZm9ydHVuZS01MDBzLWFjdHVhbGx5LXVzZQ==
+), I explained how it is the path to a $171K remote job (on
+average) and how it can lead to a life of complete independence
+as a freelancer and business owner.
+
+I've gotten extremely positive feedback on these posts.
+
+But I also received a lot of questions.
+
+The main one being: how do I start?
+
+How do I begin learning Kubernetes?
+
+​
+
+To address this question, I decided to build a free course that
+will help people get started on their Kubernetes journey.
+
+It's called the 7-Day Kubernetes Quickstart.
+
+And because you are a valued member of the KubeCraft newsletter,
+I'm giving you early access before anyone else.
+
+You can claim your free course here:
+
+​https://go.kubecraft.dev/k8s-quickstart (
+https://click.convertkit-mail2.com/8kuxxp309muoh2k5z53ikhk680599b3hom0k6/g3hnh5hmpw378kbr/aHR0cHM6Ly9nby5rdWJlY3JhZnQuZGV2L2s4cy1xdWlja3N0YXJ0
+)​
+
+Just use the same email that you received this mail on.
+
+​
+
+Enjoy your free course, and see you next week!
+
+Mischa
+
+​
+
+P.S. We have opened up 10 new spots for the KubeCraft Career
+Accelerator, and one of them is already claimed. If you want to
+land a remote 6-figure DevOps job, this is your chance. CLICK
+HERE (
+https://click.convertkit-mail2.com/8kuxxp309muoh2k5z53ikhk680599b3hom0k6/9qhzhnhd9rpkv2a9/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svNTA4ZDU2
+)to claim your spot.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://unsubscribe.convertkit-mail2.com/8kuxxp309muoh2k5z53ikhk680599b3hom0k6
+) | Update your profile (
+https://preferences.convertkit-mail2.com/8kuxxp309muoh2k5z53ikhk680599b3hom0k6
+)

--- a/mvb_k8s/emails/Your-Kubernetes-Quickstart-Course.md
+++ b/mvb_k8s/emails/Your-Kubernetes-Quickstart-Course.md
@@ -1,0 +1,32 @@
+# Your Kubernetes Quickstart Course
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Mon, 08 Dec 2025 20:01:47 +0000
+
+---
+
+Hello!
+
+Thanks for signing up.
+
+Click the link below to confirm your subscription and to get
+access to your free Kubernetes course.
+
+​
+
+-->Confirm your subscription (
+https://click.convertkit-mail2.com/0vuoo9zlr0hqfo9e8kxslhvzgdx55snh9x384/dpheh0he5n02w3im/aHR0cHM6Ly9hcHAua2l0LmNvbS9mb3Jtcy9jb25maXJtP2tleT1mNWQ4ZmEyZTIzNjJlYzI1Nzc4Y2Y2OWU0YjE3MjlkNjRmNWNhZTZmJnNpZD0xMTA1MTM1MzIwMg==
+)
+Confirm your subscription (
+https://app.kit.com/forms/confirm?key=f5d8fa2e2362ec25778cf69e4b1729d64f5cae6f&sid=11051353202
+)​
+
+Unsubscribe (
+https://unsubscribe.convertkit-mail2.com/0vuoo9zlr0hqfo9e8kxslhvzgdx55snh9x384
+) | Update your profile (
+https://preferences.convertkit-mail2.com/0vuoo9zlr0hqfo9e8kxslhvzgdx55snh9x384
+) | 113 Cherry St #92768, Seattle, WA 98104-2205
+
+(
+https://click.convertkit-mail2.com/0vuoo9zlr0hqfo9e8kxslhvzgdx55snh9x384/n2hohvhvrm57wnc6/aHR0cHM6Ly9idWlsdHdpdGgua2l0LmNvbT91dG1fY2FtcGFpZ249cG93ZXJlZGJ5JnV0bV9jb250ZW50PWVtYWlsJnV0bV9tZWRpdW09cmVmZXJyYWwmdXRtX3NvdXJjZT1keW5hbWlj
+)

--- a/mvb_k8s/emails/Your-Kubernetes-journey-starts-now.md
+++ b/mvb_k8s/emails/Your-Kubernetes-journey-starts-now.md
@@ -1,0 +1,412 @@
+# Your Kubernetes journey starts now
+
+**From:** Mischa van den Burg <news@kubecraft.dev>  
+**Date:** Mon, 08 Dec 2025 20:16:21 +0000
+
+---
+
+Hey Adam,
+
+​
+
+Welcome to the 7-day Kubernetes quickstart.
+
+By the end of this week, you’ll have:
+
+* A real Kubernetes cluster running on your machine
+* Deployed multiple applications
+* Built a self-hosted bookmark manager you’ll actually use
+* Understood pods, deployments, services, and persistent storage
+
+No fluff. No theory overload. Just hands-on learning.
+
+But before we touch any tools, let me explain what Kubernetes
+actually is. Most tutorials skip this and leave you confused.
+
+The Problem Kubernetes Solves
+
+Imagine you’re running a web application. It lives on a server.
+Life is simple.
+
+Then your app gets popular. One server can’t handle the traffic.
+So you add more servers. Now you have 10 servers running your
+app.
+
+Questions start piling up:
+
+* How do you deploy updates to all 10 servers?
+* What happens when one server crashes at 3am?
+* How do you scale up during peak hours and scale down at night?
+* How do servers know about each other?
+* How does traffic get distributed between them?
+
+You could write scripts. Use Ansible. Hire someone to babysit
+servers.
+
+Or you could use Kubernetes.
+
+Kubernetes is a container orchestrator. You tell it “I want 10
+copies of my app running” and it figures out the rest. It
+distributes them across servers. It restarts them when they
+crash. It scales them up and down based on demand.
+
+You declare what you want. Kubernetes makes it happen.
+
+That’s the core idea. Everything else is details.
+
+Why Containers?
+
+Kubernetes runs containers, not regular applications.
+
+A container is a lightweight, isolated package that includes your
+application and everything it needs to run. Code, libraries,
+dependencies, configuration. All bundled together.
+
+Think of it like shipping containers on a cargo ship. Before
+shipping containers existed, loading a ship was chaos. Different
+sized boxes, barrels, crates. Every port had different equipment.
+
+Then someone invented the standard shipping container. Now any
+crane at any port can handle any container. The contents don’t
+matter. The interface is standardized.
+
+Software containers work the same way. Your app might need Python
+3.12, specific libraries, certain environment variables. Instead
+of installing all that on every server, you package it into a
+container. That container runs the same way everywhere. Your
+laptop, a test server, production, the cloud.
+
+Kubernetes doesn’t care what’s inside the container. It just
+knows how to run containers, restart them, scale them, and
+connect them together.
+
+The Kubernetes Cluster
+
+A Kubernetes cluster is a set of machines working together.
+
+There are two types of machines:
+
+Control Plane
+
+The brain. It stores the cluster state, makes scheduling
+decisions, and responds to your commands. In production, you
+usually have 3 control plane nodes for redundancy.
+
+Worker Nodes
+
+The muscle. These are the machines that actually run your
+containers. You might have 3, 30, or 300 worker nodes depending
+on your scale.
+
+When you run a command like “deploy my app with 5 copies,” the
+control plane receives that request, decides which worker nodes
+have capacity, and tells those nodes to start containers.
+
+For learning, you only need one machine that acts as both control
+plane and worker. That’s what we’re setting up today.
+
+Let’s Get Started: Install Rancher Desktop
+
+Rancher Desktop is a free, open-source tool that creates a
+complete Kubernetes cluster on your laptop.
+
+I’ve taught Kubernetes to over 1,000 people. I’ve tested every
+local Kubernetes option out there. Minikube, Kind, Docker
+Desktop, K3d, MicroK8s. After hundreds of hours of research and
+troubleshooting student issues, Rancher Desktop is what I
+recommend.
+
+Here’s why:
+
+* One-click install with no complex configuration
+* Works everywhere including Windows, Mac (including Apple
+Silicon), and Linux
+* Free forever with no license costs or enterprise upsells
+* Uses K3s which is a lightweight but fully-compliant Kubernetes
+distribution
+* Includes kubectl so you have the command-line tool you need
+* Handles the VM by creating and managing the Linux virtual
+machine for you
+
+Step 1: Download and Install
+
+Go to https://rancherdesktop.io (
+https://click.convertkit-mail2.com/0vuoo9zlr0hguox5x7zclhvzgdx55snh9x384/vqh3hrhogl3wnwcg/aHR0cHM6Ly9yYW5jaGVyZGVza3RvcC5pbw==
+)​
+
+Download the version for your operating system. Install it like
+any other application.
+
+When you first launch it, Rancher Desktop will:
+
+1. Create a Linux virtual machine on your computer
+
+2. Install K3s (Kubernetes) inside that VM
+
+3. Configure kubectl to talk to your new cluster
+
+4. Start all the necessary system components
+
+​
+
+This takes a few minutes. You’ll see a progress indicator. Wait
+until you see a green checkmark. That means your cluster is
+ready.
+
+Step 2: Verify Your Cluster
+
+Open your terminal:
+
+- Mac: Terminal or iTerm
+
+- Windows: PowerShell (not Command Prompt)
+
+- Linux: Your terminal of choice
+
+​
+
+Run this command:
+
+​
+kubectl get nodes
+​
+
+You should see output like:
+
+​
+NAME STATUS ROLES AGE
+VERSION
+rancher-desktop Ready control-plane,master 5m
+v1.34.3+k3s1
+​
+
+Let’s break this down:
+
+* NAME: The name of your node (machine)
+* STATUS: “Ready” means it’s healthy and can run workloads
+* ROLES: This node is both control-plane and master (same thing,
+different terminology)
+* AGE: How long the node has been running
+* VERSION: The Kubernetes version (K3s in this case)
+
+If you see “Ready” then congratulations. You have a working
+Kubernetes cluster.
+
+Troubleshooting
+
+If you get “command not found: kubectl”:
+
+Rancher Desktop needs to add kubectl to your system PATH. Go to
+Rancher Desktop, then Preferences, then Application, then Path.
+
+Make sure it’s set to “Automatic” or manually add the path to
+your shell configuration. Then restart your terminal.
+
+If the node shows “NotReady”:
+
+The cluster might still be starting up. Wait another minute and
+try again. If it persists, try going to Rancher Desktop, then
+Troubleshooting, then Reset Kubernetes.
+
+If you get “connection refused”:
+
+Rancher Desktop isn’t running. Open the app and wait for the
+green checkmark.
+
+​
+
+Step 3: Explore Your Cluster
+
+Let’s run a few more commands to understand what we’re working
+with.
+
+​
+
+See all pods running in the cluster:
+
+​
+kubectl get pods -A
+​
+
+The -A flag means “all namespaces.” You’ll see system pods that
+Kubernetes needs to function:
+
+​
+NAMESPACE NAME READY
+STATUS
+kube-system coredns-59b4f5bbd5-xxxxx 1/1
+Running
+kube-system local-path-provisioner-6c86858495-xxxxx 1/1
+Running
+kube-system metrics-server-67c658944b-xxxxx 1/1
+Running
+kube-system svclb-traefik-xxxxx 2/2
+Running
+kube-system traefik-f4564c4f4-xxxxx 1/1
+Running
+​
+
+Don’t worry about understanding all of these yet. Just know
+they’re system components:
+
+- coredns: Handles DNS inside the cluster
+
+- traefik: An ingress controller for routing traffic
+- metrics-server: Collects resource usage data
+
+- local-path-provisioner: Handles storage
+
+​
+
+See what’s in the default namespace:
+
+​
+kubectl get pods
+​
+
+You’ll see “No resources found in default namespace.” That’s
+expected. We haven’t deployed anything yet.
+
+​
+
+Step 4: Deploy Your First Pod
+
+Now let’s deploy something.
+
+Run this:
+
+​
+kubectl run my-nginx --image=nginx
+​
+
+What just happened?
+
+* You told Kubernetes “create a pod called my-nginx using the
+nginx image”
+* Kubernetes pulled the nginx container image from Docker Hub
+* It created a pod and started the container inside it
+* The nginx web server is now running
+
+​
+
+Check it:
+
+​
+kubectl get pods
+​
+
+​
+NAME READY STATUS RESTARTS AGE
+my-nginx 1/1 Running 0 30s
+​
+
+READY 1/1 means 1 out of 1 containers in the pod are ready.
+
+STATUS Running means the pod is healthy.
+
+RESTARTS 0 means it hasn’t crashed.
+
+​
+
+Step 5: Explore Your Pod
+
+Let’s learn more about this pod.
+
+Get detailed information:
+
+​
+kubectl describe pod my-nginx
+​
+
+This outputs a lot. Key sections:
+
+* Containers: Shows the nginx container, its image, and state
+* Conditions: Shows if the pod is scheduled, initialized, and
+ready
+* Events: Shows what happened like image pulled, container
+started, etc.
+
+​
+
+See the logs:
+
+​
+kubectl logs my-nginx
+​
+
+This shows whatever nginx is outputting. Not much yet since no
+one is visiting it.
+
+​
+
+Execute a command inside the container:
+
+​
+kubectl exec -it my-nginx -- /bin/bash
+​
+
+You’re now inside the container. You can look around:
+
+​
+ls /usr/share/nginx/html
+cat /usr/share/nginx/html/index.html
+exit
+​
+
+That index.html is the default nginx welcome page.
+
+Step 6: Clean Up
+
+Delete the pod:
+
+​
+kubectl delete pod my-nginx
+​
+
+Verify it’s gone:
+
+​
+kubectl get pods
+​
+
+“No resources found in default namespace.”
+
+What You Learned Today
+
+* Kubernetes is a container orchestrator. You declare what you
+want, it makes it happen
+* Containers are portable, isolated packages for running
+applications
+* A cluster has control plane nodes (brain) and worker nodes
+(muscle)
+* kubectl is your command-line tool for talking to Kubernetes
+* A pod is the smallest unit in Kubernetes. It’s a wrapper around
+one or more containers
+* Basic commands: kubectl get, kubectl describe, kubectl logs,
+kubectl exec, kubectl delete
+
+Tomorrow, we level up. Instead of a single pod that disappears
+when deleted, we’ll create deployments and watch Kubernetes
+automatically heal when things break.
+
+This is where it gets fun.
+
+Mischa
+
+​
+
+P.S. If you’re serious about landing a DevOps job, this free
+course is just the starting point. Inside KubeCraft, I have 50+
+hours of production-grade projects, Weekly coaching calls, and a
+community of 800+ engineers. Over 1,000 people have used this
+system to land roles at Google, Microsoft, and Amazon. CLICK HERE
+(
+https://click.convertkit-mail2.com/0vuoo9zlr0hguox5x7zclhvzgdx55snh9x384/l2hehmhlrevxodf6/aHR0cHM6Ly9rdWJlY3JhZnQuY2xpY2svZTU5ZjZj
+) to apply and see if you qualify.
+
+​
+113 Cherry St #92768, Seattle, WA 98104-2205 | Unsubscribe (
+https://unsubscribe.convertkit-mail2.com/0vuoo9zlr0hguox5x7zclhvzgdx55snh9x384
+) | Update your profile (
+https://preferences.convertkit-mail2.com/0vuoo9zlr0hguox5x7zclhvzgdx55snh9x384
+)


### PR DESCRIPTION
## Summary
- Converted 16 raw `.eml` files to clean markdown
- Stripped all email headers containing PII (personal email, bounce paths, DKIM, SPF, etc.)
- Only subject, sender (public address), date, and body content preserved
- One reply email had personal email in From field — replaced with generic text

## Context
The original `.eml` files were scrubbed from git history earlier due to PII exposure on this public repo. This restores the learning content in a safe format.

Closes #218