### PR TITLE
Publish Jellyfin iGPU migration blog post

### DIFF
--- a/site/content/posts/2025-11-30-jellyfin-igpu-migration.md
+++ b/site/content/posts/2025-11-30-jellyfin-igpu-migration.md
@@ -1,235 +1,103 @@
 ---
-title: "Journal Entry - 2025-11-30"
+title: "Replacing a Discrete GPU with Intel iGPU for Jellyfin Transcoding"
 date: 2025-11-30
-draft: true
-tags: ["proxmox", "gpu-passthrough", "containers", "media-server", "lxc"]
+draft: false
+tags: ["proxmox", "gpu-passthrough", "jellyfin", "media-server", "lxc"]
+description: "Migrating Jellyfin from an AMD RX 570 to Intel HD 630 iGPU — 90% less power, same transcoding performance."
 ---
 
+I migrated Jellyfin from an AMD RX 570 to the Intel HD Graphics 630 integrated into the host CPU. The result: 4 simultaneous HEVC transcodes at ~10% CPU each, with a ~105-135W power reduction.
 
-## Jellyfin Hardware Transcoding Migration: AMD RX 570 → Intel iGPU
+## Why Switch
 
-Successfully migrated Jellyfin (LXC 3001 on pve005) from AMD discrete GPU to Intel integrated graphics for hardware-accelerated transcoding. Significant power savings with excellent performance.
+The AMD RX 570 was overkill for transcoding. It pulled 50-70W at idle and 120-150W under load — running 24/7 in a media server that mostly handles a few streams at a time. The Intel iGPU built into the i5-7500 has Quick Sync Video, which is purpose-built for exactly this workload.
 
-## Hardware Details
+## Hardware Changes
 
-### pve005 Specifications
-- **CPU**: Intel Core i5-7500 (Kaby Lake, 4 cores @ 3.40GHz)
-- **iGPU**: Intel HD Graphics 630
-- **Memory**: 16 GB RAM
-- **Previous GPU**: AMD Radeon RX 570 (removed)
+Shut down the host, physically removed the RX 570, and enabled the iGPU in BIOS under Advanced > Graphics > "Internal Graphics."
 
-### Intel HD 630 Capabilities
-- **Quick Sync Video**: Generation 9.5
-- **Hardware Codecs**: H.264, HEVC (H.265), VP9, VP8, MPEG-2, VC-1, JPEG
-- **Max Resolution**: 4K (4096x2304)
-- **Simultaneous Streams**: 3-5+ (1080p HEVC transcodes)
+After reboot, verified detection:
 
-## Migration Process
-
-### 1. Hardware Changes
-- Shut down pve005 safely (stopped LXC 108 and 3001)
-- Physically removed AMD RX 570 GPU
-- Removed bad NVMe devices (bad_nvme pool previously destroyed)
-- Enabled iGPU in BIOS
-  - Setting: Advanced → Graphics → "Internal Graphics" or "iGPU Multi-Monitor"
-  - Both iGPU and discrete GPU can be enabled if needed
-
-### 2. Host Configuration
-After reboot, verified iGPU detection:
 ```bash
 lspci | grep VGA
-# Output: 00:02.0 VGA compatible controller: Intel Corporation HD Graphics 630 (rev 04)
+# 00:02.0 VGA compatible controller: Intel Corporation HD Graphics 630 (rev 04)
 
 ls -la /dev/dri/
-# Output:
 # crw-rw---- 1 root video  226,   1 card1
 # crw-rw---- 1 root render 226, 128 renderD128
 ```
 
-Group IDs:
-- video: GID 44
-- render: GID 104
+## LXC Configuration
 
-### 3. LXC Container Configuration
-LXC 3001 config (`/etc/pve/lxc/3001.conf`) automatically included GPU passthrough:
+The Jellyfin container already had GPU passthrough configured. The LXC config passes both device nodes with the correct group IDs:
+
 ```ini
 dev2: /dev/dri/card1,gid=44
 dev3: /dev/dri/renderD128,gid=104
-features: keyctl=1,nesting=1,fuse=1
 ```
 
-### 4. Intel Media Drivers (Already Installed)
-Container already had proper drivers:
-- **Driver**: i965-va-driver (Intel i965 VAAPI driver)
-- **Version**: 2.4.1-1
-- **API**: VA-API 1.20.0
+The Intel VAAPI driver (`i965-va-driver`) was already installed in the container. Verified with `vainfo`:
 
-Verified with `vainfo`:
 ```bash
 vainfo
 # Driver: Intel i965 driver for Intel(R) Kaby Lake - 2.4.1
 # Supports: H.264, HEVC, VP9 encode/decode
 ```
 
-### 5. Jellyfin Configuration
-Jellyfin encoding settings (`/etc/jellyfin/encoding.xml`):
+## Jellyfin Settings
+
+In the Jellyfin encoding config, the key setting is using **VAAPI** — not QSV. On Linux, QSV uses the VAAPI backend anyway, so VAAPI is the right choice for Intel iGPUs:
+
 ```xml
 <HardwareAccelerationType>vaapi</HardwareAccelerationType>
 <VaapiDevice>/dev/dri/renderD128</VaapiDevice>
-<QsvDevice>/dev/dri/renderD128</QsvDevice>
 ```
 
-**Important**: For Intel iGPUs on Linux, use **VAAPI** (not QSV). QSV uses VAAPI under the hood on Linux anyway.
+## Performance Results
 
-Jellyfin user permissions:
-```bash
-id jellyfin
-# uid=107(jellyfin) gid=110(jellyfin) groups=110(jellyfin),44(video),993(render),104(_ssh)
-```
+Tested with 4 simultaneous transcodes, all requiring HEVC encoding with resolution scaling. All ffmpeg processes showed hardware acceleration active (`hevc_vaapi`):
 
-## Performance Testing
+| Metric | RX 570 | Intel HD 630 |
+|--------|--------|--------------|
+| Idle power | 50-70W | ~15W |
+| Transcoding power | 120-150W | 15-20W |
+| CPU per stream | N/A | ~10% |
+| 4-stream load avg | N/A | 2.90 |
+| Memory usage | N/A | 1.4 GB / 4 GB |
 
-### Test: 4 Simultaneous Transcodes
-Tested with 4 different media files playing simultaneously, all requiring transcoding to HEVC with resolution scaling.
+The I/O wait was 83% during the test — the bottleneck was disk reads, not encoding. The iGPU had headroom to spare.
 
-**ffmpeg Command Verification:**
-All processes showed hardware acceleration:
-```bash
-/usr/lib/jellyfin-ffmpeg/ffmpeg \
-  -init_hw_device vaapi=va:/dev/dri/renderD128,driver=iHD \
-  -hwaccel vaapi \
-  -hwaccel_output_format vaapi \
-  -codec:v:0 hevc_vaapi \
-  -vf scale_vaapi=format=nv12:extra_hw_frames=24
-```
+**Estimated annual savings:** ~920-1,180 kWh (~$100-150/year at $0.11/kWh), plus a cooler, quieter system.
 
-**System Load:**
-- CPU usage per stream: ~10% each
-- Total load average: 2.90
-- Memory usage: 1.4 GB / 4 GB
-- I/O wait: 83% (disk reading, not CPU encoding)
+## VAAPI vs QSV on Linux
 
-**Comparison:**
-- **CPU transcoding** (software): Would use ~100% CPU per stream = 400% load
-- **GPU transcoding** (Intel HD 630): ~10% CPU per stream = 40% load
-- **CPU savings**: 90% per stream offloaded to iGPU
+This tripped me up initially. Intel offers two APIs:
 
-## Power Consumption
+- **VAAPI**: Native Linux video acceleration API
+- **QSV (Quick Sync Video)**: Intel's proprietary API
 
-### Before (AMD RX 570)
-- Idle: ~50-70W
-- Under load (transcoding): ~120-150W
-- 24/7 operation: Significant power draw
+On Linux, QSV uses the VAAPI backend under the hood. Use VAAPI directly — it's simpler and avoids an unnecessary abstraction layer.
 
-### After (Intel HD 630)
-- Idle: ~15W
-- Under load (transcoding): ~15-20W
-- 24/7 operation: Minimal power draw
+There are also two driver options for the HD 630:
 
-**Estimated Savings:**
-- ~105-135W reduction under transcoding load
-- Annual savings: ~920-1,180 kWh (if transcoding 24/7)
-- Cost savings: ~$100-150/year (at $0.11/kWh)
-- Heat reduction: Cooler, quieter system
-
-## Technical Learnings
-
-### VAAPI vs QSV on Linux
-- **VAAPI**: Native Linux API for hardware acceleration
-- **QSV (Quick Sync Video)**: Intel's proprietary technology
-- On Linux, QSV uses VAAPI backend anyway
-- **Recommendation**: Use VAAPI for Intel iGPUs on Linux
-
-### i965 vs iHD Drivers
-- **i965**: Older, stable driver for Gen 4-9 Intel GPUs (HD Graphics 630 is Gen 9.5)
+- **i965**: Older, stable driver for Gen 4-9.5 Intel GPUs
 - **iHD**: Newer Intel Media Driver for Gen 8+
-- Both drivers were available, ffmpeg chose iHD (`driver=iHD`)
-- Both work fine, iHD may have newer codec support
 
-### LXC GPU Passthrough
-- Unprivileged LXC can access GPU with proper device passthrough
-- GID mapping: host GID → container GID (may show as `_ssh` for render group)
-- Must map both `/dev/dri/cardX` (video) and `/dev/dri/renderDX` (render)
+Both work. The ffmpeg processes chose iHD (`driver=iHD`), which may have newer codec support.
 
-### Intel Quick Sync Generations
-- HD 630 (Kaby Lake): 9th generation Quick Sync
-- Excellent HEVC support (10-bit)
-- Hardware-accelerated tone mapping available
-- VP9 encode/decode support
+## When iGPU Makes Sense
+
+Intel iGPU is ideal for:
+- 24/7 media server transcoding (power efficiency)
+- Up to 5-7 simultaneous 1080p transcodes
+- Setups where power and heat matter
+
+Keep the discrete GPU for:
+- Gaming VMs with GPU passthrough
+- Heavy compute (AI inference, rendering)
+- More than 7 simultaneous transcodes
+- AV1 encoding (newer iGPUs support this)
 
 ## Outcome
 
-**Success Metrics:**
-- ✅ 4 simultaneous HEVC transcodes at ~10% CPU each
-- ✅ System load healthy (2.90 avg)
-- ✅ ~105-135W power savings
-- ✅ Hardware acceleration confirmed (`hevc_vaapi` in ffmpeg commands)
-- ✅ No quality degradation
-- ✅ Excellent thermal efficiency
-
-**AMD RX 570 Status:**
-- Removed from pve005
-- Available for other uses (pve007/pve009, gaming, compute workloads)
-- Better suited for gaming VMs or heavy compute than 24/7 transcoding
-
-## Architecture Benefits
-
-### Why Intel iGPU is Better for Jellyfin
-1. **Power Efficiency**: 7-10x less power consumption
-2. **Always Available**: Built into CPU, no extra hardware
-3. **Quick Sync**: Purpose-built for video encoding/decoding
-4. **Thermal**: Minimal heat generation
-5. **Reliability**: Designed for continuous operation
-6. **Cost**: No additional hardware cost
-
-### When to Use Discrete GPU (AMD/NVIDIA)
-1. Heavy compute workloads (AI, rendering)
-2. Gaming VMs
-3. Multiple containers need GPU simultaneously
-4. More than 5-7 simultaneous transcodes
-5. Advanced features (HDR tone mapping, AV1 encoding)
-
-## Recommendations for Similar Setups
-
-### For Intel 6th-10th Gen CPUs with iGPU
-1. Enable iGPU in BIOS (even with discrete GPU installed)
-2. Pass through to LXC: `/dev/dri/card*` and `/dev/dri/renderD*`
-3. Install i965-va-driver in container
-4. Configure Jellyfin for VAAPI (not QSV on Linux)
-5. Verify with `vainfo` and test transcode
-6. Monitor with `intel_gpu_top` (may have issues in LXC)
-
-### Optimal Container Settings
-- Memory: 4-8 GB sufficient
-- CPU cores: 2-4 cores adequate (GPU does heavy lifting)
-- Storage: Fast disk for media library (NVMe/SSD preferred)
-- Network: Gigabit minimum for 4K streaming
-
-## Next Steps
-
-**Completed:**
-- Intel iGPU migration and validation
-- 4-stream performance test passed
-- Power consumption reduced
-
-**Future Optimizations:**
-- Consider HDR tone mapping (VPP tone mapping on Intel)
-- Monitor long-term stability
-- Test AV1 decode capability
-- RX 570s now in pve007 (new pve007 with 2x RX 570)
-
-## Summary
-
-Successfully migrated Jellyfin from AMD discrete GPU to Intel integrated graphics. The i5-7500's HD Graphics 630 handles 4 simultaneous HEVC transcodes effortlessly while consuming 90% less power. Intel Quick Sync proves to be the ideal solution for 24/7 media server transcoding workloads.
-
-**Key Win**: Right hardware for the right job - iGPU excels at continuous video transcoding with minimal power draw.
-
----
-
-**Status**: Production - Jellyfin running efficiently on Intel HD 630
-
-**Mood**: Satisfied - Perfect example of power efficiency and performance optimization
-
-**Time spent**: ~1 hour (hardware swap, BIOS config, testing)
-
-**Power savings**: ~105-135W continuous (very significant for 24/7 operation)
+The RX 570 was freed up for gaming VMs on another host where it actually makes sense. The i5-7500's iGPU handles Jellyfin's transcoding workload at a fraction of the power draw. Right hardware for the right job.


### PR DESCRIPTION
## Summary
- Rewrite the Nov 30, 2025 journal entry into a blog post
- Covers migrating Jellyfin from AMD RX 570 to Intel HD 630 iGPU
- Topics: VAAPI vs QSV on Linux, LXC GPU passthrough, power savings
- Set `draft: false` to publish to lab.8devops.com