### PR TITLE
Fix netdata cloud verification failing in --check mode

### DIFF
--- a/ansible/roles/netdata/tasks/main.yml
+++ b/ansible/roles/netdata/tasks/main.yml
@@ -108,6 +108,7 @@
 
 - name: Verify netdata cloud connection
   ansible.builtin.command: /usr/sbin/netdatacli aclk-state
+  check_mode: false
   register: netdata_aclk_status
   changed_when: false
   until: "'Claimed: Yes' in netdata_aclk_status.stdout and 'Online: Yes' in netdata_aclk_status.stdout"


### PR DESCRIPTION
## Summary
- Add `check_mode: false` to the `Verify netdata cloud connection` task so it executes during `--check` dry runs
- This task only reads `aclk-state` and never modifies anything, so it's safe to run in check mode
- Fixes the "Test Against Infrastructure" CI job which has been failing on all pve hosts

## Test plan
- [x] `ansible-lint ansible/roles/netdata/` passes clean (production profile)
- [ ] CI "Test Against Infrastructure" job should pass after merge