### PR TITLE
Add ASCII architecture diagram to gaming VM blog post

### DIFF
--- a/site/content/posts/2025-11-12-proxmox-gaming-vms-gpu-passthrough.md
+++ b/site/content/posts/2025-11-12-proxmox-gaming-vms-gpu-passthrough.md
@@ -12,6 +12,56 @@ My two boys each had their own gaming PC. Two towers, two sets of peripherals, t
 
 The plan: one host, two GPUs, two Windows VMs. Each boy gets a dedicated GPU, their own monitor, keyboard, and mouse. They can game simultaneously without knowing they're on virtual machines.
 
+```
+  BEFORE
+  ──────
+  ┌──────────────┐         ┌──────────────┐
+  │  Gaming PC #1│         │  Gaming PC #2│
+  │              │         │              │
+  │  RTX 3080   │         │  RTX 3080    │
+  │  Win 11     │         │  Win 11      │
+  │  Monitor    │         │  Monitor     │
+  │  KB+Mouse   │         │  KB+Mouse    │
+  └──────────────┘         └──────────────┘
+   2 towers · 2x maintenance
+   2x power · 2x updates
+   kids control the power button
+
+
+  AFTER
+  ─────
+                        ┌──────────────────────────────────────────────┐
+                        │          pve008 (Proxmox Host)               │
+                        │     AMD Ryzen 9 5900X · 64GB RAM             │
+                        │          SSH-only (headless)                  │
+                        ├──────────────────────────────────────────────┤
+                        │  IOMMU Group 26       IOMMU Group 27         │
+                        │  ┌──────────────┐     ┌──────────────┐       │
+                        │  │  RTX 3080 #1 │     │  RTX 3080 #2 │       │
+                        │  │  vfio-pci     │     │  vfio-pci     │      │
+                        │  └──────┬───────┘     └──────┬───────┘       │
+                        │         │                    │               │
+                        │  ┌──────▼───────┐     ┌──────▼───────┐       │
+                        │  │  VM 701      │     │  VM 702      │       │
+                        │  │  Windows 11  │     │  Windows 11  │       │
+                        │  │  8 cores     │     │  8 cores     │       │
+                        │  │  32GB RAM    │     │  32GB RAM    │       │
+                        │  │  750GB disk  │     │  750GB disk  │       │
+                        │  └──────┬───────┘     └──────┬───────┘       │
+                        └─────────┼────────────────────┼───────────────┘
+                                  │                    │
+                        ┌─────────▼────────┐  ┌───────▼──────────┐
+                        │  Monitor #1      │  │  Monitor #2      │
+                        │  Keyboard #1     │  │  Keyboard #2     │
+                        │  Mouse #1        │  │  Mouse #2        │
+                        └──────────────────┘  └──────────────────┘
+                              SEB's Desk            RTB's Desk
+
+                        1 host · SSH managed
+                        snapshots · backups
+                        dad controls the power button
+```
+
 ## The LXC Detour
 
 I started where most container enthusiasts start: trying to do it in LXC. Lighter than VMs, better resource sharing, GPU passthrough "should work."


### PR DESCRIPTION
## Summary
- Adds a before/after ASCII diagram to the dual-GPU gaming VM blog post
- Shows the physical-to-virtual consolidation: two standalone PCs → one Proxmox host with IOMMU groups, dedicated GPUs, and per-desk peripherals
- Placed after "The Problem" section to set the stage visually

## Test plan
- [ ] Verify diagram renders correctly in Hugo (`hugo server`)
- [ ] Check diagram doesn't overflow on mobile/narrow viewports