### PR TITLE
Switch pi-burg backup disk to 8TB with UUID mount

### DIFF
--- a/ansible/inventory/README.md
+++ b/ansible/inventory/README.md
@@ -53,8 +53,8 @@ The `homelab.yml` inventory includes:
 - **k3s_cluster:** Parent group containing all k3s nodes
 
 ### Backup Infrastructure
-- **backup_servers:** `pibackup` - Raspberry Pi with 2TB USB backup storage
-- **media_servers:** `jellyfin` - Media server backing up to pibackup
+- **backup_servers:** `pi-burg` - Raspberry Pi with 8TB USB backup storage
+- **media_servers:** `jellyfin` - Media server backing up to pi-burg
 
 ## Host Variables
 

--- a/ansible/inventory/homelab.yml
+++ b/ansible/inventory/homelab.yml
@@ -36,7 +36,7 @@ all:
       hosts:
         pi-burg:
           ansible_user: adambehn
-          backup_disk_device: /dev/sda2
+          backup_disk_uuid: ffbe8e24-8713-4c30-8500-1474d7adc397
           backup_mount_point: /mnt/backup
 
     # Kubernetes Cluster (Currently decommissioned)

--- a/ansible/roles/backup_server/defaults/main.yml
+++ b/ansible/roles/backup_server/defaults/main.yml
@@ -2,7 +2,7 @@
 # Backup server defaults
 
 # Disk configuration (typically overridden per-host in inventory)
-backup_disk_device: /dev/sda1
+backup_disk_uuid: ""
 backup_mount_point: /mnt/backup
 backup_filesystem_type: ext4
 

--- a/ansible/roles/backup_server/tasks/disk.yml
+++ b/ansible/roles/backup_server/tasks/disk.yml
@@ -10,7 +10,7 @@
     mode: "0755"
 
 - name: Check if disk is already formatted
-  ansible.builtin.command: blkid -s TYPE -o value {{ backup_disk_device }}
+  ansible.builtin.command: blkid -s TYPE -o value /dev/disk/by-uuid/{{ backup_disk_uuid }}
   register: disk_filesystem
   changed_when: false
   failed_when: false
@@ -18,13 +18,13 @@
 - name: Format disk if not already formatted
   community.general.filesystem:
     fstype: "{{ backup_filesystem_type }}"
-    dev: "{{ backup_disk_device }}"
+    dev: "/dev/disk/by-uuid/{{ backup_disk_uuid }}"
   when: disk_filesystem.stdout == ""
 
 - name: Mount backup disk
   ansible.posix.mount:
     path: "{{ backup_mount_point }}"
-    src: "{{ backup_disk_device }}"
+    src: "UUID={{ backup_disk_uuid }}"
     fstype: "{{ backup_filesystem_type }}"
     opts: defaults,nofail
     state: mounted


### PR DESCRIPTION
## Summary
- Migrated pi-burg backup disk from 2TB to 8TB drive
- Changed mount config from device path (`/dev/sda2`) to UUID (`ffbe8e24-8713-4c30-8500-1474d7adc397`) for reliability
- Fixed stale hostname (`pibackup` → `pi-burg`) and size (`2TB` → `8TB`) in inventory README

## Test plan
- [ ] Run `ansible-playbook -i inventory/homelab.yml backup-setup.yml --check --diff` against pi-burg
- [ ] Verify fstab shows `UUID=ffbe8e24-...` instead of `/dev/sda2`
- [ ] Reboot pi-burg and confirm auto-mount
- [ ] Run a test backup from jellyfin

Closes #244