### PR TITLE
Add attr package to Proxmox default packages

### DIFF
--- a/ansible/roles/proxmox/defaults/main.yml
+++ b/ansible/roles/proxmox/defaults/main.yml
@@ -17,3 +17,4 @@ proxmox_default_packages:
   - ncdu
   - lsof
   - strace
+  - attr


### PR DESCRIPTION
## Summary
- Add `attr` package to `proxmox_default_packages` in the proxmox role
- Provides `setfattr`/`getfattr` commands needed for setting CephFS directory layout pool attributes (e.g., pinning directories to HDD or SSD CRUSH rule pools)

## Test plan
- [ ] CI passes ansible-lint and `--check --diff`
- [ ] Verify `attr` is installed after deploy: `dpkg -l attr`