### PR TITLE
Replace jellyfin with jellyfin01 in Ansible inventory

### DIFF
--- a/ansible/inventory/homelab.yml
+++ b/ansible/inventory/homelab.yml
@@ -36,10 +36,10 @@ all:
         pve02:  # Ryzen 9 5900X, 64GB, 1x RTX 3080 Ti, Aquantia 10G + Intel I225-V 2.5G
         pve03:  # Ryzen 9 5900X, 128GB, 2x RTX 3080, Intel I225-V 2.5G
 
-    # Media Servers
+    # Media Servers (VLAN 70, new cluster LXCs)
     media_servers:
       hosts:
-        jellyfin:
+        jellyfin01:  # LXC 3001 on pve01, CephFS media at /mnt/library
           ansible_user: root
 
     # SLURM Cluster (archived - VMs deleted 2026-01-30)


### PR DESCRIPTION
## Summary
- Replace old `jellyfin` (pve005 legacy cluster) with `jellyfin01` (LXC 3001, pve01 new cluster)
- Jellyfin now runs on VLAN 70 with CephFS HDD media storage

## Test plan
- [x] `ansible jellyfin01 -m ping` — SUCCESS
- [x] CI passes lint and `--check --diff`