### PR TITLE
Fix backup client targeting and add restic repo check

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,4 +1,6 @@
 [defaults]
+inventory = inventory/homelab.yml
+
 # Run tasks on more hosts in parallel (default: 5)
 forks = 20
 

--- a/ansible/backup-setup.yml
+++ b/ansible/backup-setup.yml
@@ -11,8 +11,8 @@
     - tailscale
     - backup_server
 
-- name: Configure backup client (Jellyfin)
-  hosts: jellyfin
+- name: Configure backup client
+  hosts: backup_clients
   become: true
   vars_files:
     - vault.yml

--- a/ansible/inventory/homelab.yml
+++ b/ansible/inventory/homelab.yml
@@ -45,6 +45,12 @@ all:
     # SLURM Cluster (archived - VMs deleted 2026-01-30)
     # See ansible/archive/slurm-cluster/
 
+    # Backup Clients (hosts that back up to pi-burg)
+    backup_clients:
+      hosts:
+        jellyfin01:
+          backup_server_host: 100.85.209.80  # pi-burg Tailscale IP (MagicDNS broken in LXC)
+
     # Backup Servers
     backup_servers:
       hosts:

--- a/ansible/roles/backup_client/defaults/main.yml
+++ b/ansible/roles/backup_client/defaults/main.yml
@@ -34,4 +34,10 @@ backup_apprise_urls: "{{ vault_backup_apprise_urls | default('') }}"
 
 # Script and log locations
 backup_script_path: /usr/local/bin/backup-library.sh
+backup_check_script_path: /usr/local/bin/restic-check.sh
 backup_log_path: /var/log/restic-backup.log
+
+# Weekly check schedule (default: Sunday 6am)
+backup_check_cron_hour: "6"
+backup_check_cron_minute: "0"
+backup_check_cron_weekday: "0"

--- a/ansible/roles/backup_client/tasks/restic.yml
+++ b/ansible/roles/backup_client/tasks/restic.yml
@@ -49,6 +49,25 @@
     user: root
     state: present
 
+- name: Deploy restic check script
+  ansible.builtin.template:
+    src: restic-check.sh.j2
+    dest: "{{ backup_check_script_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  no_log: true
+
+- name: Setup weekly restic check cron
+  ansible.builtin.cron:
+    name: "Restic repository check"
+    minute: "{{ backup_check_cron_minute }}"
+    hour: "{{ backup_check_cron_hour }}"
+    weekday: "{{ backup_check_cron_weekday }}"
+    job: "{{ backup_check_script_path }}"
+    user: root
+    state: present
+
 - name: Deploy logrotate config
   ansible.builtin.copy:
     src: logrotate

--- a/ansible/roles/backup_client/templates/restic-check.sh.j2
+++ b/ansible/roles/backup_client/templates/restic-check.sh.j2
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# Restic repository integrity check - managed by Ansible
+# Runs weekly to verify backup data on Pi backup server
+
+LOGFILE="{{ backup_log_path }}"
+RESTIC_REPOSITORY="sftp:{{ backup_server_user }}@{{ backup_server_host }}:{{ backup_server_repo_path }}"
+RESTIC_PASSWORD="{{ restic_password }}"
+
+export RESTIC_REPOSITORY
+export RESTIC_PASSWORD
+
+{% if backup_notify_enabled | default(false) %}
+APPRISE_URLS="{{ backup_apprise_urls }}"
+
+notify() {
+    local title="$1"
+    local body="$2"
+    if [ -n "$APPRISE_URLS" ] && command -v apprise &>/dev/null; then
+        apprise -t "$title" --body "$body" "$APPRISE_URLS" 2>/dev/null || true
+    fi
+}
+{% endif %}
+
+log_message() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" | tee -a "$LOGFILE"
+}
+
+log_message "Starting restic repository check"
+
+if ! ping -c 1 -W 5 {{ backup_server_host }} > /dev/null 2>&1; then
+    log_message "ERROR: Backup server {{ backup_server_host }} is not reachable"
+{% if backup_notify_enabled | default(false) %}
+    notify "Restic check FAILED on $(hostname)" "Server {{ backup_server_host }} unreachable at $(date)"
+{% endif %}
+    exit 1
+fi
+
+CHECK_OUTPUT=$(restic check 2>&1) && CHECK_RC=0 || CHECK_RC=$?
+echo "$CHECK_OUTPUT" >> "$LOGFILE"
+
+if [ $CHECK_RC -eq 0 ]; then
+    log_message "Repository check passed"
+{% if backup_notify_enabled | default(false) %}
+    notify "Restic check OK on $(hostname)" "Repository integrity verified at $(date)"
+{% endif %}
+else
+    log_message "Repository check FAILED with exit code $CHECK_RC"
+{% if backup_notify_enabled | default(false) %}
+    notify "Restic check FAILED on $(hostname)" "Repository check failed with code $CHECK_RC at $(date). Check $LOGFILE for details."
+{% endif %}
+    exit $CHECK_RC
+fi


### PR DESCRIPTION
## Summary
- Add `backup_clients` inventory group so backup role isn't tied to hostname (fixes broken targeting after jellyfin → jellyfin01 rename)
- Set `backup_server_host` to pi-burg's Tailscale IP for jellyfin01 (MagicDNS broken in LXC)
- Add default inventory path to `ansible.cfg`
- Add weekly restic repository integrity check (Sundays 6am) with apprise notifications

## Test plan
- [x] `ansible-playbook backup-setup.yml --check --diff` — clean run
- [x] `ansible-playbook backup-setup.yml` — deployed successfully
- [x] Nightly restic backup confirmed working (Mar 12 02:00)
- [ ] Wait for Sunday 6am to confirm restic check cron fires