### PR TITLE
Add smartmontools to backup server role

### DIFF
--- a/ansible/roles/backup_server/tasks/restic.yml
+++ b/ansible/roles/backup_server/tasks/restic.yml
@@ -1,9 +1,11 @@
 ---
 # Install restic and initialize repository
 
-- name: Install restic
+- name: Install restic and smartmontools
   ansible.builtin.apt:
-    name: restic
+    name:
+      - restic
+      - smartmontools
     state: present
     update_cache: true
     cache_valid_time: 3600


### PR DESCRIPTION
## Summary
- Install `smartmontools` alongside restic in the `backup_server` role
- Enables netdata SMART disk monitoring and alerting on pi-burg
- Already installed manually; this ensures Ansible manages it going forward

## Test plan
- [x] smartmontools already installed and working on pi-burg
- [x] netdata collecting SMART data after restart
- [ ] Ansible lint + CI pass