### PR TITLE
Add Jellyfin config to restic backup

### DIFF
--- a/ansible/inventory/homelab.yml
+++ b/ansible/inventory/homelab.yml
@@ -50,6 +50,18 @@ all:
       hosts:
         jellyfin01:
           backup_server_host: 100.85.209.80  # pi-burg Tailscale IP (MagicDNS broken in LXC)
+          backup_paths:
+            - /mnt/library
+            - /var/lib/jellyfin
+            - /etc/jellyfin
+          backup_excludes:
+            - "*.tmp"
+            - "lost+found"
+            - "tmp/"
+            - "cache/"
+            - "transcodes/"
+            - "log/"
+            - "*.log*"
 
     # Backup Servers
     backup_servers:


### PR DESCRIPTION
## Summary
- Add `/var/lib/jellyfin` and `/etc/jellyfin` to restic backup paths on jellyfin01
- Excludes cache, transcodes, and logs (matches rclone backup filters)
- ~82 MiB additional data, negligible with restic dedup

## Test plan
- [ ] CI passes
- [ ] Run `ansible-playbook backup-setup.yml --check --diff` to verify template renders with new paths
- [ ] Next 2am backup includes Jellyfin config dirs

Closes #268