### PR TITLE
Optimize CI pipeline with container image and gitleaks action

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+COPY ansible/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+# GitHub Actions runs as root in containers — ensure git trusts the workspace
+RUN git config --system --add safe.directory '*'

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -11,20 +11,11 @@ jobs:
   lint:
     name: Ansible Lint
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/8do-abehn/lab/ansible-ci:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: 'ansible/requirements.txt'
-
-      - name: Install Ansible and ansible-lint
-        run: |
-          pip install -r ansible/requirements.txt
 
       - name: Run ansible-lint
         run: |

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,40 @@
+---
+name: Build CI Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ansible/requirements.txt'
+      - '.github/ci/Dockerfile'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/ansible-ci
+
+jobs:
+  build:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/ci/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,15 +16,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install gitleaks
-        run: |
-          GITLEAKS_VERSION="8.21.2"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
-
       - name: Run gitleaks
-        run: |
-          gitleaks detect \
-            --config .gitleaks.toml \
-            --baseline-path .gitleaksbaseline \
-            --verbose
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml


### PR DESCRIPTION
## Summary
- Add pre-built Docker image for ansible lint job to skip pip install on every run
- Add `build-ci-image` workflow to auto-rebuild image on requirements.txt or Dockerfile changes
- Switch gitleaks from pinned binary download to official `gitleaks-action@v2`
- Keep `test-infrastructure` job on setup-python (Tailscale incompatible with GHA job containers)

## Bootstrap
The CI image needs to exist before the lint job can use it. After merging, trigger the `Build CI Image` workflow manually via `workflow_dispatch` to push the initial image to GHCR.

## Test plan
- [ ] Manually trigger `Build CI Image` workflow to push initial container image
- [ ] Verify lint job runs successfully with container image
- [ ] Verify test-infrastructure job still passes with Tailscale + SSH
- [ ] Verify gitleaks uses custom `.gitleaks.toml` rules
- [ ] Compare run times before/after

Closes #276