### PR TITLE
Install git in CI container image

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY ansible/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt


### PR DESCRIPTION
## Summary
- Install git in the CI Dockerfile — `python:3.11-slim` doesn't include it
- Needed for `git config --system safe.directory` and `actions/checkout`

## Test plan
- [ ] Merge, then trigger `Build CI Image` workflow
- [ ] Verify image builds and pushes to GHCR