### PR TITLE
Add iptables MASQUERADE for LAN-to-Tailscale subnet routing

### DIFF
--- a/ansible/roles/tailscale/tasks/sysctl.yml
+++ b/ansible/roles/tailscale/tasks/sysctl.yml
@@ -6,3 +6,27 @@
     sysctl_set: true
     state: present
     reload: true
+
+- name: Install iptables-persistent for rule persistence across reboots
+  ansible.builtin.apt:
+    name: iptables-persistent
+    state: present
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Check if MASQUERADE rule exists
+  ansible.builtin.command: iptables -t nat -C POSTROUTING -o tailscale0 -j MASQUERADE
+  register: tailscale_masquerade_check
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
+- name: Add MASQUERADE rule for LAN-to-Tailscale traffic
+  ansible.builtin.command: iptables -t nat -A POSTROUTING -o tailscale0 -j MASQUERADE
+  when: tailscale_masquerade_check.rc != 0
+  changed_when: true
+
+- name: Save iptables rules to persist across reboots
+  ansible.builtin.command: netfilter-persistent save
+  when: tailscale_masquerade_check.rc != 0
+  changed_when: true


### PR DESCRIPTION
## Summary
- Adds MASQUERADE rule on tailscale0 so non-Tailscale LAN devices can reach Tailscale services through the subnet router (dns01)
- Installs `iptables-persistent` to persist rules across reboots
- Idempotent: checks if rule exists before adding, only saves when changed

## Context
Without MASQUERADE, return traffic from Tailscale peers (e.g., jellyfin01) has no route back to the LAN source IP. NAT rewrites the source to the subnet router's Tailscale IP so replies route correctly.

## Test plan
- [x] Verified `curl http://100.93.207.33:8096` returns 302 from Mac (Tailscale off)
- [x] Verified `curl http://100.93.207.33:8096` returns 302 from EdgeRouter
- [x] Verified rules persist in `/etc/iptables/rules.v4`
- [ ] CI lint + check pass