### PR TITLE
Publish OpenMemory MCP blog post

### DIFF
--- a/site/content/posts/2026-03-31-openmemory-mcp-proxmox-tailscale.md
+++ b/site/content/posts/2026-03-31-openmemory-mcp-proxmox-tailscale.md
@@ -1,7 +1,7 @@
 ---
 title: "Self-Hosting OpenMemory MCP on Proxmox with Tailscale"
 date: 2026-03-31
-draft: true
+draft: false
 tags: ["homelab", "proxmox", "docker", "ai", "mcp", "tailscale", "ollama"]
 description: "Deploying a self-hosted OpenMemory MCP server on a Proxmox LXC with Ollama and Tailscale, plus fixing Claude Desktop's broken write tools with supergateway."
 ---


### PR DESCRIPTION
## Summary
- Set `draft: false` on the OpenMemory MCP blog post to publish it

## Test plan
- [ ] Blog builds with `hugo --minify`
- [ ] Post appears at lab.8devops.com