### PR TITLE
Set Minecraft server version to LATEST

### DIFF
--- a/ansible/roles/minecraft/defaults/main.yml
+++ b/ansible/roles/minecraft/defaults/main.yml
@@ -10,7 +10,7 @@ minecraft_monitor_image: "itzg/mc-monitor:latest"
 
 # Server defaults (overridable per server)
 minecraft_server_type: "PAPER"
-minecraft_version: "1.21.4"
+minecraft_version: "LATEST"
 minecraft_eula: "TRUE"
 minecraft_default_memory: "4G"
 minecraft_default_max_players: 20


### PR DESCRIPTION
## Summary
- Unpins `minecraft_version` from `1.21.4` to `LATEST` in role defaults
- All servers (Paper + Fabric) will pull the latest release on next container recreate

## Test plan
- [ ] Run `ansible-playbook site.yml --check --diff -l mc03` to verify template renders
- [ ] Recreate containers and confirm servers start on latest version