### PR TITLE
Pin Minecraft version to 1.21.11

### DIFF
--- a/ansible/roles/minecraft/defaults/main.yml
+++ b/ansible/roles/minecraft/defaults/main.yml
@@ -10,7 +10,7 @@ minecraft_monitor_image: "itzg/mc-monitor:latest"
 
 # Server defaults (overridable per server)
 minecraft_server_type: "PAPER"
-minecraft_version: "LATEST"
+minecraft_version: "1.21.11"
 minecraft_eula: "TRUE"
 minecraft_default_memory: "4G"
 minecraft_default_max_players: 20


### PR DESCRIPTION
## Summary
- Pin `minecraft_version` to `1.21.11` (latest Paper build)
- Fixes Fabric crash: 26.1.1 requires Java 25, container runs Java 21

## Test plan
- [ ] Deploy to mc03 and confirm modded server starts
- [ ] Verify survival server on mc01 stays on 1.21.11