### PR TITLE
Switch Minecraft servers to Vanilla 26.1.1 on Java 25

### DIFF
--- a/ansible/inventory/host_vars/mc03.yml
+++ b/ansible/inventory/host_vars/mc03.yml
@@ -13,4 +13,3 @@ minecraft_servers:
     port: 25566
     memory: "8G"
     motd: "Modded Server"
-    server_type: FABRIC

--- a/ansible/roles/minecraft/defaults/main.yml
+++ b/ansible/roles/minecraft/defaults/main.yml
@@ -4,13 +4,13 @@
 minecraft_compose_dir: /opt/minecraft
 
 # Container images
-minecraft_server_image: "itzg/minecraft-server:java21"
+minecraft_server_image: "itzg/minecraft-server:java25"
 minecraft_backup_image: "itzg/mc-backup:latest"
 minecraft_monitor_image: "itzg/mc-monitor:latest"
 
 # Server defaults (overridable per server)
-minecraft_server_type: "PAPER"
-minecraft_version: "1.21.11"
+minecraft_server_type: "VANILLA"
+minecraft_version: "26.1.1"
 minecraft_eula: "TRUE"
 minecraft_default_memory: "4G"
 minecraft_default_max_players: 20
@@ -26,7 +26,7 @@ minecraft_backup_prune_days: 7
 # RCON (enabled by default, random password per server if not set)
 minecraft_default_rcon_password: "{{ vault_minecraft_rcon_password }}"
 
-# Auto-update: weekly cron to pull latest Paper builds
+# Auto-update: weekly cron to pull latest builds
 minecraft_auto_update_enabled: true
 minecraft_auto_update_weekday: "0"
 minecraft_auto_update_hour: "4"


### PR DESCRIPTION
## Summary
- Switch from Paper to Vanilla (Paper doesn't support 26.x yet)
- Update image tag from java21 to java25 (Minecraft 26.x requires Java 25)
- Pin version to 26.1.1
- Remove Fabric override on mc03 modded server

## Tested
- [x] Deployed to mc01, client connected successfully on 26.1.1

## Test plan
- [ ] Deploy to mc02 and mc03
- [ ] Verify all 6 servers start and accept connections