### PR TITLE
Add SkyBlock server on mc01 port 25567

### DIFF
--- a/ansible/inventory/host_vars/mc01.yml
+++ b/ansible/inventory/host_vars/mc01.yml
@@ -15,6 +15,7 @@ minecraft_servers:
   - name: oneblock
     port: 25567
     memory: "4G"
+    version: "26.1"
     motd: "SkyBlock"
     extra_env:
       MODRINTH_PROJECTS: "datapack:standard-skyblock,datapack:sky-void-additions"


### PR DESCRIPTION
## Summary
- Add oneblock server on mc01 port 25567 using Standard SkyBlock + Sky Void Additions datapacks
- Pin to version 26.1 for datapack compatibility (26.1.1 files not yet published on Modrinth)
- Vanilla server type on java25 image

## Tested
- [x] Server starts and loads both datapacks
- [x] Client connects and spawns on skyblock island at Y=66
- [x] Backup sidecar running

## Notes
- First connect may spawn at Y=-63 (void) — reconnecting fixes it
- Datapacks: standard-skyblock (island + void worldgen) + sky-void-additions (all items obtainable)