### PR TITLE
Add SkyBlock servers for Sawyer and Riley

### DIFF
--- a/ansible/inventory/host_vars/mc02.yml
+++ b/ansible/inventory/host_vars/mc02.yml
@@ -11,3 +11,19 @@ minecraft_servers:
     port: 25566
     memory: "4G"
     motd: "Minigames Server"
+
+  - name: sawyer-skyblock
+    port: 25567
+    memory: "4G"
+    version: "26.1"
+    motd: "Sawyer's SkyBlock"
+    extra_env:
+      MODRINTH_PROJECTS: "datapack:standard-skyblock,datapack:sky-void-additions"
+
+  - name: riley-skyblock
+    port: 25568
+    memory: "4G"
+    version: "26.1"
+    motd: "Riley's SkyBlock"
+    extra_env:
+      MODRINTH_PROJECTS: "datapack:standard-skyblock,datapack:sky-void-additions"


### PR DESCRIPTION
## Summary
- Sawyer's SkyBlock on mc02 port 25567
- Riley's SkyBlock on mc02 port 25568
- Same datapacks as mc01 oneblock: Standard SkyBlock + Sky Void Additions
- Pinned to 26.1 for datapack compatibility

## Test plan
- [ ] Deploy to mc02 and confirm both servers start
- [ ] Both kids can connect from 26.1.1 client