### PR TITLE
Remove unused Minecraft servers from mc02 and mc03

### DIFF
--- a/ansible/inventory/host_vars/mc02.yml
+++ b/ansible/inventory/host_vars/mc02.yml
@@ -1,17 +1,6 @@
 ---
 # Minecraft servers on mc02 (LXC 3005 on pve02, 32GB RAM)
 minecraft_servers:
-  - name: adventure
-    port: 25565
-    memory: "6G"
-    difficulty: hard
-    motd: "Adventure Server"
-
-  - name: minigames
-    port: 25566
-    memory: "4G"
-    motd: "Minigames Server"
-
   - name: sawyer-skyblock
     port: 25567
     memory: "4G"

--- a/ansible/inventory/host_vars/mc03.yml
+++ b/ansible/inventory/host_vars/mc03.yml
@@ -1,15 +1,3 @@
 ---
 # Minecraft servers on mc03 (LXC 3006 on pve03, 32GB RAM)
-minecraft_servers:
-  - name: hardcore
-    port: 25565
-    memory: "6G"
-    difficulty: hard
-    motd: "Hardcore Server"
-    extra_env:
-      HARDCORE: "true"
-
-  - name: modded
-    port: 25566
-    memory: "8G"
-    motd: "Modded Server"
+minecraft_servers: []


### PR DESCRIPTION
## Summary
- Remove adventure + minigames from mc02
- Remove hardcore + modded from mc03
- mc03 now empty for future use

## Test plan
- [ ] Deploy to mc02 and mc03
- [ ] Verify removed containers are stopped
- [ ] Manually clean up old Docker volumes after deploy