### PR TITLE
Add Cobblemon server on mc03

### DIFF
--- a/ansible/inventory/host_vars/mc03.yml
+++ b/ansible/inventory/host_vars/mc03.yml
@@ -1,3 +1,13 @@
 ---
 # Minecraft servers on mc03 (LXC 3006 on pve03, 32GB RAM)
-minecraft_servers: []
+minecraft_servers:
+  - name: cobblemon
+    port: 25565
+    memory: "8G"
+    version: "1.21.1"
+    server_type: FABRIC
+    image: "itzg/minecraft-server:java21"
+    motd: "Cobblemon"
+    extra_env:
+      MODRINTH_PROJECTS: "cobblemon,fabric-api"
+      MODRINTH_DOWNLOAD_DEPENDENCIES: "required"

--- a/ansible/roles/minecraft/templates/docker-compose.yml.j2
+++ b/ansible/roles/minecraft/templates/docker-compose.yml.j2
@@ -4,7 +4,7 @@
 services:
 {% for server in minecraft_servers %}
   mc-{{ server.name }}:
-    image: {{ minecraft_server_image }}
+    image: {{ server.image | default(minecraft_server_image) }}
     container_name: mc-{{ server.name }}
     ports:
       - "{{ server.port }}:25565"


### PR DESCRIPTION
## Summary
- Cobblemon (Pokemon) server on mc03 port 25565
- Fabric 1.21.1 with java21 image
- Auto-downloads Cobblemon + Fabric API + dependencies from Modrinth
- Add per-server image override to compose template (needed for mixed java versions)

## Test plan
- [ ] Deploy to mc03, confirm server starts
- [ ] Create 1.21.1 launcher profile and connect
- [ ] Verify Pokemon spawn in world