### PR TITLE
Prune unused (not just dangling) images in mem0 auto-update

### DIFF
--- a/ansible/roles/mem0/tasks/service.yml
+++ b/ansible/roles/mem0/tasks/service.yml
@@ -81,6 +81,6 @@
       cd {{ mem0_compose_dir }} &&
       docker compose pull --quiet &&
       docker compose up -d &&
-      docker image prune -f
+      docker image prune -a -f
       >> /var/log/mem0-update.log 2>&1
   when: mem0_auto_update_enabled


### PR DESCRIPTION
## Summary
- Weekly auto-update cron on mem01 was running `docker image prune -f`, which only removes *dangling* (untagged) images
- In practice it reclaimed **0B every week** while 17 GB of tagged-but-unused images piled up in containerd overlayfs
- Swapping to `docker image prune -a -f` removes unused tagged images too, which is what the cron was meant to do

## Why this is safe
- `-a` only removes images with no container referencing them
- Because this runs *after* `docker compose up -d`, active services protect their images
- Only truly orphaned images (old Ollama/OpenWebUI versions after a pull) get removed

## Test plan
- [ ] Run the role against mem01 on next deploy
- [ ] Verify `/var/log/mem0-update.log` shows reclaimed space on next Sunday 4:30am run
- [ ] Confirm mem0 stack still comes up cleanly