### PR TITLE
Upgrade netdata packages in lockstep to avoid wedged iU state

### DIFF
--- a/ansible/roles/netdata/tasks/main.yml
+++ b/ansible/roles/netdata/tasks/main.yml
@@ -67,6 +67,7 @@
       dpkg-query -W -f='${db:Status-Abbrev} ${Package}\n' 'netdata*' 2>/dev/null \
         | awk '/^ii/ {print $2}' \
         | grep -v '^netdata-repo$' || true
+    executable: /bin/bash
   register: netdata_installed_pkgs
   changed_when: false
   check_mode: false

--- a/ansible/roles/netdata/tasks/main.yml
+++ b/ansible/roles/netdata/tasks/main.yml
@@ -56,11 +56,29 @@
     update_cache: true
     cache_valid_time: 3600
 
+# Query currently-installed netdata packages so we can upgrade them all
+# in lockstep. Plugin packages have strict `Depends: netdata (= X.Y.Z)`
+# pins, so upgrading only `netdata` leaves plugins wedged in iU state
+# when the repo publishes split-version updates.
+- name: Query installed netdata packages
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      dpkg-query -W -f='${db:Status-Abbrev} ${Package}\n' 'netdata*' 2>/dev/null \
+        | awk '/^ii/ {print $2}' \
+        | grep -v '^netdata-repo$' || true
+  register: netdata_installed_pkgs
+  changed_when: false
+  check_mode: false
+
 # Distro packages are built with --disable-cloud, so state: latest
-# ensures official repo package (with cloud support) replaces them
+# ensures official repo package (with cloud support) replaces them.
+# On fresh installs the query returns nothing and apt pulls plugins
+# in via `netdata`'s dependencies; on upgrades all currently-installed
+# netdata packages are passed together so apt resolves them atomically.
 - name: Install netdata # noqa: package-latest
   ansible.builtin.apt:
-    name: netdata
+    name: "{{ (['netdata'] + netdata_installed_pkgs.stdout_lines) | unique | list }}"
     state: latest
 
 - name: Check if already claimed


### PR DESCRIPTION
## Summary
- The netdata role runs `apt install netdata state=latest`, but plugin packages have strict `Depends: netdata (= X.Y.Z)` pins
- When the netdata repo publishes a split-version update, apt refuses the single-package upgrade and plugins get stuck in `iU` (unpacked, not configured) state
- dns01 hit this today: 12 plugins were unpacked at 2.10.0 while core was at 2.9.0, and CI kept failing with `Unmet dependencies` — no amount of reruns could resolve it
- Fix: query installed netdata packages with `dpkg-query` and pass them to apt as a single list so the upgrade is resolved atomically

## Behavior
- **Fresh install:** query returns empty → apt installs `netdata` → plugins pulled in as deps (unchanged from today)
- **Upgrade:** query returns all installed netdata packages → apt upgrades them in lockstep → no wedged states

## Why it happens
The netdata apt repo occasionally publishes new versions where the `netdata` meta-package lands before (or without) corresponding plugin bumps. Because plugins pin the exact version, apt can't resolve a partial upgrade and ends up half-unpacking them. This is a known netdata packaging quirk.

## Test plan
- [ ] CI `Test Against Infrastructure` passes now that dns01 was manually repaired
- [ ] Running the role against any netdata host should be a no-op if already at the latest version
- [ ] If a future split-version update happens, this task should upgrade everything together instead of wedging