### PR TITLE
Add rockbox-nano project for Jellyfin → iPod sync

### DIFF
--- a/projects/rockbox-nano/.gitignore
+++ b/projects/rockbox-nano/.gitignore
@@ -1,0 +1,17 @@
+# Compiled binary — rebuild via setup.sh
+ipodpatcher
+
+# Downloaded blobs — re-fetch via setup.sh
+bootloader-ipodnano2g.ipodx
+rockbox-ipodnano2g-*.zip
+mbr-nano2g*.bin
+
+# Apple firmware backups (encrypted blob from the device, large)
+apple-original-firmware.ipodx
+apple-original-firmware.bin
+
+# Transcoded music staging (large, regenerable from jellyfin)
+staging/
+
+# macOS junk
+.DS_Store

--- a/projects/rockbox-nano/README.md
+++ b/projects/rockbox-nano/README.md
@@ -1,0 +1,144 @@
+# rockbox-nano
+
+Replaces Apple Music + Finder sync for an **iPod nano 2nd gen** (model A1199) by:
+
+1. Installing **Rockbox 4.0** as the iPod's firmware (one-time, dual-boots with Apple OS)
+2. Pulling music from the Jellyfin server (`jellyfin01:/mnt/library/music/`) over the tailnet
+3. Transcoding any FLAC tracks to 192k MP3 on the way to the device
+4. Treating the iPod as a plain USB mass-storage device — no iTunes database, no Apple Music
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `setup.sh` | Builds `ipodpatcher` from source and downloads the bootloader + firmware zip. Idempotent. |
+| `sync-to-ipod.sh` | Pulls selected artists, transcodes FLAC, copies to `/Volumes/BEHN IPOD/Music/`. Dry-run by default. |
+| `.gitignore` | Excludes the compiled binary, downloaded blobs, and the staging dir. |
+
+## One-time setup
+
+```sh
+./setup.sh                       # builds ipodpatcher + downloads bootloader + firmware zip
+```
+
+This populates `~/8do/rockbox-nano/` with the binaries and blobs. Override with `ROCKBOX_NANO_WORKDIR=...`.
+
+## One-time Rockbox install (per iPod)
+
+> Pre-requisite: confirm the iPod is `winpod` (FAT32). On macOS, Apple Music typically formats as HFS+ (`macpod`) which Rockbox cannot use. The nano needs to be in FAT32 — either it already is (pre-existing Windows-formatted iPod) or it can be converted on macOS using `mbr-nano2g.bin` + `ipodpatcher -f`.
+
+```sh
+cd ~/8do/rockbox-nano
+
+# Backup the original Apple firmware (insurance — keep the .ipodx file safe)
+sudo ./ipodpatcher -rf apple-original-firmware.ipodx
+
+# Install the Rockbox bootloader (writes to firmware partition only)
+sudo ./ipodpatcher -a bootloader-ipodnano2g.ipodx
+
+# Extract the Rockbox firmware files to the iPod's data partition
+unzip -o rockbox-ipodnano2g-4.0.zip -d "/Volumes/BEHN IPOD/"
+
+diskutil eject "/Volumes/BEHN IPOD"
+```
+
+On reboot the iPod loads the Rockbox bootloader, which then loads `.rockbox/rockbox.ipod` from the data partition.
+
+**Dual-boot keys (during boot):**
+
+- *No key* → Rockbox
+- *Hold `Menu`* → Apple firmware (chained from `OSBK` slot in firmware partition)
+- *Hold `Select`* (center) → Apple disk mode (USB mass storage recovery)
+
+## Verifying the bootloader is installed
+
+```sh
+sudo ./ipodpatcher --list
+```
+
+The "Main firmware" image should be ~52 KB (Rockbox bootloader). If it's several MB, that's Apple firmware and the bootloader install hasn't happened.
+
+## Music sync
+
+Edit the `ARTISTS` array in `sync-to-ipod.sh`. Entries are `<subdir>/<Artist Name>` relative to `/mnt/library/music/` on jellyfin (e.g. `library/Sturgill Simpson`, `krista/Nine Inch Nails`).
+
+```sh
+./sync-to-ipod.sh           # dry-run
+./sync-to-ipod.sh --go      # actually copy to iPod
+```
+
+Re-runnable; `rsync --size-only` skips files already on the iPod, and the FLAC transcode loop only acts on remaining `.flac` files.
+
+## Playlists
+
+Rockbox auto-discovers `.m3u`/`.m3u8` files in `/Playlists/` on the iPod. Generate one with absolute paths from the iPod root:
+
+```sh
+mkdir -p "/Volumes/BEHN IPOD/Playlists"
+find "/Volumes/BEHN IPOD/Music/Radiohead" -type f \
+    \( -iname "*.mp3" -o -iname "*.m4a" -o -iname "*.flac" \) ! -name "._*" \
+    | sort | sed "s|/Volumes/BEHN IPOD||" \
+    > "/Volumes/BEHN IPOD/Playlists/Radiohead.m3u8"
+```
+
+Use `.m3u8` (UTF-8) when track names contain unicode characters.
+
+## Battery health
+
+Check live battery voltage on-device: **System → Debug → View Battery** in Rockbox.
+
+For nano 2g specifically, the original Apple recall (overheating) only applied to the 1st generation. The 2nd gen is safe but a 20-year-old cell will be capacity-degraded — see [lab issue #365](../../../../issues/365) for replacement notes (requires soldering, see [iFixit Guide #422](https://www.ifixit.com/Guide/iPod+Nano+2nd+Generation+Battery+Replacement/422)).
+
+## Design notes
+
+A few things that took debugging the first time around — preserved here so the next person (probably future-me) doesn't repeat them:
+
+### Use GNU rsync, not Apple's openrsync
+
+macOS ships `openrsync` which lacks `--protect-args` (`-s`). That flag is mandatory when remote paths contain spaces (and they will — "Sturgill Simpson", "A Moon Shaped Pool", etc.) because the remote shell otherwise re-interprets the filenames.
+
+```sh
+brew install rsync   # puts GNU rsync 3.x first in PATH
+```
+
+### `ffmpeg -nostdin` is mandatory inside `while read` loops
+
+Without it, ffmpeg reads from the loop's stdin (which is the `find -print0` pipe), consumes random bytes from upcoming filenames, and the loop iterates over corrupted paths. Symptom: only the first FLAC transcodes, then the script either dies on a mangled path or silently exits with no warning. Took an hour to figure out.
+
+### `-vn` drops embedded album art
+
+The nano's screen is too small for embedded cover art and Rockbox reads art from a separate `cover.jpg` per album folder anyway. Stripping it speeds the encode ~5x and avoids ffmpeg's bizarre still-image-as-video warnings.
+
+### macOS resource forks pollute the source
+
+The cephfs library has `._<filename>` AppleDouble files everywhere from past Mac copies. Excluded via `--exclude='._*'` in rsync — Rockbox will try to parse them as audio files and choke otherwise.
+
+### iPod must be `winpod` (FAT32), not `macpod` (HFS+)
+
+If `ipodpatcher --scan` reports "macpod", you need the conversion path:
+
+```sh
+curl -fLO https://download.rockbox.org/bootloader/ipod/mbr-nano2g-2GB.bin   # or 4GB variant
+diskutil unmountDisk /dev/diskN          # double-check N from `diskutil list`!
+sudo dd if=mbr-nano2g-2GB.bin of=/dev/diskN bs=512 count=1
+sudo ./ipodpatcher -f                    # format data partition as FAT32
+# then proceed with bootloader install
+```
+
+The `dd` step is the high-stakes part; verify `diskN` matches the iPod size (2GB or 4GB) before running.
+
+### Reclaiming legacy iTunes space
+
+Once Rockbox is confirmed working, the old `iPod_Control/` directory from Apple's sync era is wasted space (Rockbox doesn't read iTunesDB). Free it:
+
+```sh
+rm -rf "/Volumes/BEHN IPOD/iPod_Control"
+```
+
+This recovered ~1.6 GB on a 4 GB nano. Calendars/Contacts/Notes are separate top-level folders and unaffected.
+
+## References
+
+- [Rockbox iPod Nano 2nd Gen port](https://www.rockbox.org/wiki/IPodNano2GPort)
+- [Rockbox 4.0 manual for ipodnano2g](https://download.rockbox.org/manual/rockbox-ipodnano2g/)
+- [iFixit nano 2g battery replacement guide #422](https://www.ifixit.com/Guide/iPod+Nano+2nd+Generation+Battery+Replacement/422)

--- a/projects/rockbox-nano/setup.sh
+++ b/projects/rockbox-nano/setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Bootstrap the rockbox-nano workspace.
+# Idempotent: re-running just verifies/refreshes anything missing.
+#
+# Builds ipodpatcher from source and downloads the firmware bits needed
+# to install Rockbox 4.0 on an iPod nano 2nd generation (model A1199).
+#
+# After running this, see README.md for the install procedure.
+set -euo pipefail
+
+WORKDIR="${ROCKBOX_NANO_WORKDIR:-$HOME/8do/rockbox-nano}"
+ROCKBOX_VERSION="4.0"
+ROCKBOX_SRC_REPO="https://github.com/Rockbox/rockbox.git"
+DL_BASE="https://download.rockbox.org"
+
+log() { printf '[setup] %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v git  >/dev/null || die "git required"
+command -v make >/dev/null || die "make required (xcode-select --install)"
+command -v cc   >/dev/null || die "cc required (xcode-select --install)"
+command -v curl >/dev/null || die "curl required"
+
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+# --- ipodpatcher (built from source; no working macOS binary upstream) ----
+# Rockbox only ships a 2010 Intel macOS dmg of ipodpatcher which doesn't run
+# on modern macOS. The C source builds cleanly with the system toolchain.
+if [[ ! -x ./ipodpatcher ]]; then
+    log "compiling ipodpatcher from source"
+    if [[ ! -d /tmp/rockbox-src ]]; then
+        git clone --depth 1 "$ROCKBOX_SRC_REPO" /tmp/rockbox-src
+    fi
+    make -C /tmp/rockbox-src/utils/ipodpatcher >/dev/null
+    cp /tmp/rockbox-src/utils/ipodpatcher/ipodpatcher ./ipodpatcher
+    chmod +x ./ipodpatcher
+else
+    log "ipodpatcher already built"
+fi
+
+# --- bootloader (encrypted .ipodx for nano2g) -----------------------------
+if [[ ! -f bootloader-ipodnano2g.ipodx ]]; then
+    log "downloading nano2g bootloader"
+    curl -fLO "$DL_BASE/bootloader/ipod/bootloader-ipodnano2g.ipodx"
+else
+    log "bootloader already present"
+fi
+
+# --- Rockbox firmware zip (extracted to iPod's data partition) ------------
+ROCKBOX_ZIP="rockbox-ipodnano2g-${ROCKBOX_VERSION}.zip"
+if [[ ! -f "$ROCKBOX_ZIP" ]]; then
+    log "downloading Rockbox $ROCKBOX_VERSION for ipodnano2g"
+    curl -fLO "$DL_BASE/release/${ROCKBOX_VERSION}/${ROCKBOX_ZIP}"
+else
+    log "$ROCKBOX_ZIP already present"
+fi
+
+log "done. workspace: $WORKDIR"
+log "run sync-to-ipod.sh (dry-run by default; --go to write to iPod)"

--- a/projects/rockbox-nano/sync-to-ipod.sh
+++ b/projects/rockbox-nano/sync-to-ipod.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Sync selected artists from jellyfin01 cephfs to a Rockbox iPod.
+# Transcodes FLAC to MP3 on the fly; leaves m4a/AAC as-is.
+# Dry-run by default; pass --go to actually copy.
+set -euo pipefail
+
+JELLYFIN_HOST="jellyfin01"
+MUSIC_ROOT="/mnt/library/music"
+IPOD_MOUNT="/Volumes/BEHN IPOD"
+STAGING="$HOME/8do/rockbox-nano/staging"
+BITRATE="192k"
+# Artists are stored as "<subdir>/<Artist Name>" relative to MUSIC_ROOT.
+# Staging uses just the basename so the iPod ends up with /Music/<Artist>/...
+ARTISTS=(
+    "library/Sturgill Simpson"
+    "library/Radiohead"
+    "library/Chris Stapleton"
+    "library/John Prine"
+    "krista/Old Crow Medicine Show"
+    "krista/My Morning Jacket"
+    "krista/Kris Kristofferson"
+    "krista/Nine Inch Nails"
+    "krista/Sonic Youth"
+    "krista/The Black Keys"
+    "krista/Smashing Pumpkins"
+    "adam/David Bowie"
+)
+
+DRY_RUN=1
+[[ "${1:-}" == "--go" ]] && DRY_RUN=0
+
+# rsync's handling of spaces in remote paths is fragile; -s (--protect-args)
+# sends filenames to the remote without letting its shell re-interpret them.
+RSYNC_OPTS=(
+    -av
+    -s
+    --exclude='._*'
+    --exclude='.DS_Store'
+    --exclude='*.log'
+    --exclude='*.cue'
+    --exclude='*.m3u'
+    --exclude='*.nfo'
+    --exclude='*.jpg'
+    --exclude='*.png'
+)
+(( DRY_RUN )) && RSYNC_OPTS+=(--dry-run)
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# --- pre-flight ----------------------------------------------------------
+command -v ffmpeg >/dev/null || die "ffmpeg not found (brew install ffmpeg)"
+command -v rsync  >/dev/null || die "rsync not found"
+ssh -o ConnectTimeout=5 -o BatchMode=yes "$JELLYFIN_HOST" true 2>/dev/null \
+    || die "cannot reach $JELLYFIN_HOST over ssh"
+
+if (( ! DRY_RUN )); then
+    [[ -d "$IPOD_MOUNT" ]] || die "iPod not mounted at $IPOD_MOUNT"
+fi
+
+mkdir -p "$STAGING"
+
+# --- stage from jellyfin -------------------------------------------------
+for entry in "${ARTISTS[@]}"; do
+    artist="$(basename "$entry")"
+    log "=== pulling: $artist ==="
+    staging_artist="$STAGING/$artist"
+    mkdir -p "$staging_artist"
+    rsync "${RSYNC_OPTS[@]}" \
+        "$JELLYFIN_HOST:$MUSIC_ROOT/$entry/" \
+        "$staging_artist/"
+done
+
+# --- transcode FLAC -> MP3 in-place in staging --------------------------
+log "=== transcoding FLAC -> MP3 @ $BITRATE ==="
+flac_count=0
+while IFS= read -r -d '' flac; do
+    ((flac_count++)) || true
+    mp3="${flac%.flac}.mp3"
+    if (( DRY_RUN )); then
+        log "  [dry-run] would transcode: ${flac#$STAGING/}"
+        continue
+    fi
+    log "  $(basename "$flac")"
+    # -nostdin: ffmpeg would otherwise read from the loop's stdin and consume
+    # the rest of the find output, causing the loop to exit after one file.
+    # -vn: drop embedded album art (the nano can't display it and it slows
+    # encoding 5x). Rockbox reads cover art from a separate cover.jpg if present.
+    ffmpeg -nostdin -hide_banner -loglevel error -y \
+        -i "$flac" \
+        -vn \
+        -codec:a libmp3lame -b:a "$BITRATE" \
+        -map_metadata 0 -id3v2_version 3 \
+        "$mp3"
+    rm -- "$flac"
+done < <(find "$STAGING" -type f -iname '*.flac' -print0)
+log "$flac_count FLAC files handled"
+
+# --- copy staging to iPod ------------------------------------------------
+if (( DRY_RUN )); then
+    log "=== dry-run; staging size: $(du -sh "$STAGING" 2>/dev/null | awk '{print $1}') ==="
+    log "run with --go to actually copy to iPod"
+    exit 0
+fi
+
+log "=== copying to iPod ==="
+mkdir -p "$IPOD_MOUNT/Music"
+rsync -av --size-only \
+    --exclude='._*' \
+    --exclude='.DS_Store' \
+    "$STAGING/" \
+    "$IPOD_MOUNT/Music/"
+
+log "=== done ==="
+du -sh "$IPOD_MOUNT/Music"/* 2>/dev/null || true
+df -h "$IPOD_MOUNT"
+sync
+log "run 'diskutil eject \"$IPOD_MOUNT\"' before unplugging"


### PR DESCRIPTION
## Summary
- Replaces the Apple Music + Finder workflow on an iPod nano 2g (A1199) with a scriptable Jellyfin → Rockbox sync
- Pulls selected artists from `jellyfin01:/mnt/library/music/` over the tailnet, transcodes FLAC to 192k MP3 in flight, copies to the iPod's FAT32 partition as plain files
- Documents the install procedure (with the macpod→winpod conversion path), the bootloader install via a self-compiled `ipodpatcher`, and several non-obvious bash gotchas worth preserving

## Why this lives in the lab repo
Closely related to lab issue #365 (battery follow-up for the same device) and not big enough to justify its own repo.

## What's included
| File | Purpose |
|---|---|
| `setup.sh` | Bootstraps the workspace: compiles `ipodpatcher` from source (Rockbox only ships a defunct 2010 Intel macOS dmg) and downloads the bootloader + firmware zip. Idempotent. |
| `sync-to-ipod.sh` | Pulls artists, transcodes FLAC, copies to `/Volumes/BEHN IPOD/Music/`. Dry-run by default; `--go` to write. |
| `README.md` | Install procedure, dual-boot key combos, design notes, references. |
| `.gitignore` | Excludes the compiled binary, downloaded blobs, transcoded staging dir, and Apple firmware backups. |

## Design notes worth remembering
Captured in the README, but the highlights:

1. **`ffmpeg -nostdin` is mandatory inside `while read` loops.** Without it ffmpeg eats bytes from the find pipe, only the first FLAC transcodes, then the script either dies on a corrupted path or silently exits with no log output. Took the most debugging time.
2. **macOS `openrsync` lacks `-s` / `--protect-args`** which is required when remote paths contain spaces (every artist and album does). Need GNU rsync via `brew install rsync`.
3. **`-vn` strips embedded album art** — encode is ~5x faster and Rockbox reads cover art from a separate `cover.jpg` per album folder anyway.
4. **`._*` AppleDouble files on cephfs** must be excluded or Rockbox tries to parse them as audio and chokes.

## Test plan
- [x] `setup.sh` runs cleanly on a fresh checkout, producing `ipodpatcher`, `bootloader-ipodnano2g.ipodx`, and `rockbox-ipodnano2g-4.0.zip`
- [x] Dry-run `./sync-to-ipod.sh` enumerates files without writing
- [x] `./sync-to-ipod.sh --go` synced 12 artists (~1.87 GB after FLAC transcode) to a real iPod nano 2g
- [x] Generated `Radiohead.m3u8` (78 tracks) in `/Playlists/`, Rockbox auto-discovers
- [x] `gitleaks` pre-commit pass clean

## Related
- #365 — battery follow-up for the same device