### PR TITLE
Update GPU passthrough host_vars after redistribution

### DIFF
--- a/ansible/inventory/host_vars/pve01.yml
+++ b/ansible/inventory/host_vars/pve01.yml
@@ -1,7 +1,11 @@
 ---
 proxmox_gpu_passthrough_enabled: true
-proxmox_gpu_vfio_ids: "1002:67df,1002:aaf0"
+proxmox_gpu_vfio_ids: "1002:67df,1002:aaf0,10de:2206,10de:1aef"
 proxmox_gpu_blacklist_drivers:
   - radeon
   - amdgpu
-proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt nomodeset"
+  - nouveau
+  - nvidia
+  - nvidiafb
+  - nvidia_drm
+proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off nomodeset"

--- a/ansible/inventory/host_vars/pve03.yml
+++ b/ansible/inventory/host_vars/pve03.yml
@@ -1,9 +1,11 @@
 ---
 proxmox_gpu_passthrough_enabled: true
-proxmox_gpu_vfio_ids: "10de:2206,10de:1aef"
+proxmox_gpu_vfio_ids: "10de:2206,10de:1aef,1002:67df,1002:aaf0"
 proxmox_gpu_blacklist_drivers:
   - nouveau
   - nvidia
   - nvidiafb
   - nvidia_drm
-proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off"
+  - radeon
+  - amdgpu
+proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off nomodeset"


### PR DESCRIPTION
## Summary
- pve01: added RTX 3080 VFIO IDs and NVIDIA driver blacklisting (gained 3080 from pve03)
- pve03: added RX 570 VFIO IDs and AMD driver blacklisting (gained new RX 570)
- Both nodes get `video=vesafb:off video=efifb:off nomodeset` in GRUB

Already applied and rebooted on both nodes. IOMMU groups clean, all GPUs bound to vfio-pci.

## Test plan
- [x] Playbook applied to pve01 and pve03
- [x] Both nodes rebooted, kernel cmdline verified
- [x] All GPUs bound to vfio-pci on both nodes
- [x] IOMMU groups clean (each GPU isolated with only its audio device)
- [ ] GPU passthrough verified on vm-rtb, vm-seb, vm-awb