### PR TITLE
Fix netdata-repo check skipped in --check mode

### DIFF
--- a/ansible/roles/netdata/tasks/main.yml
+++ b/ansible/roles/netdata/tasks/main.yml
@@ -13,6 +13,7 @@
   register: netdata_repo_check
   failed_when: false
   changed_when: false
+  check_mode: false
 
 - name: Set fact if netdata-repo is installed
   ansible.builtin.set_fact:

--- a/ansible/roles/netdata/tasks/main.yml
+++ b/ansible/roles/netdata/tasks/main.yml
@@ -137,4 +137,6 @@
   until: "'Claimed: Yes' in netdata_aclk_status.stdout and 'Online: Yes' in netdata_aclk_status.stdout"
   retries: 12
   delay: 10
-  when: netdata_claim_token | length > 0
+  when:
+    - netdata_claim_token | length > 0
+    - not ansible_check_mode


### PR DESCRIPTION
## Summary
- Add `check_mode: false` to the `dpkg-query` task that checks if netdata-repo is installed
- Without this, the task is skipped in `--check` mode, `netdata_repo_installed` evaluates to false, and the download task fires unnecessarily
- LXCs without external DNS resolution then fail on the download

## Test plan
- [ ] CI "Test Against Infrastructure" passes (mc01, mc02, mc03, jellyfin01, mem01 no longer fail)