### PR TITLE
Remove RX 570 from VFIO for VAAPI transcoding in LXCs

### DIFF
--- a/ansible/inventory/host_vars/pve01.yml
+++ b/ansible/inventory/host_vars/pve01.yml
@@ -1,11 +1,9 @@
 ---
 proxmox_gpu_passthrough_enabled: true
-proxmox_gpu_vfio_ids: "1002:67df,1002:aaf0,10de:2206,10de:1aef"
+proxmox_gpu_vfio_ids: "10de:2206,10de:1aef"
 proxmox_gpu_blacklist_drivers:
-  - radeon
-  - amdgpu
   - nouveau
   - nvidia
   - nvidiafb
   - nvidia_drm
-proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off nomodeset"
+proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off"

--- a/ansible/inventory/host_vars/pve03.yml
+++ b/ansible/inventory/host_vars/pve03.yml
@@ -1,11 +1,9 @@
 ---
 proxmox_gpu_passthrough_enabled: true
-proxmox_gpu_vfio_ids: "10de:2206,10de:1aef,1002:67df,1002:aaf0"
+proxmox_gpu_vfio_ids: "10de:2206,10de:1aef"
 proxmox_gpu_blacklist_drivers:
   - nouveau
   - nvidia
   - nvidiafb
   - nvidia_drm
-  - radeon
-  - amdgpu
-proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off nomodeset"
+proxmox_gpu_grub_extra: "amd_iommu=on iommu=pt video=vesafb:off video=efifb:off"

--- a/ansible/roles/proxmox/tasks/gpu-passthrough.yml
+++ b/ansible/roles/proxmox/tasks/gpu-passthrough.yml
@@ -1,4 +1,10 @@
 ---
+- name: Remove Proxmox installer nomodeset override
+  ansible.builtin.file:
+    path: /etc/default/grub.d/installer.cfg
+    state: absent
+  notify: Update grub
+
 - name: Configure GRUB kernel parameters for GPU passthrough
   ansible.builtin.lineinfile:
     path: /etc/default/grub


### PR DESCRIPTION
## Summary
- Remove RX 570 VFIO binding on pve01/pve03 so amdgpu loads for LXC VAAPI use
- Remove nomodeset from GRUB (blocks amdgpu probe with error -22)
- Add Ansible task to remove Proxmox installer.cfg nomodeset override
- 3080s remain in VFIO for VM passthrough

## Test plan
- [x] All 3 nodes have /dev/dri/renderD128 after reboot
- [x] vainfo confirms RX 570 VAAPI (radeonsi driver)
- [x] Jellyfin transcodes 4K HEVC to H.264 via h264_vaapi
- [x] 3080 VM passthrough still works (vm-rtb, vm-awb, vm-seb)
- [ ] CI passes