### PR TITLE
Auto-renew registered IP TTL from Access audit logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,22 @@
 - Use `cephfs-ssd` for LXC templates - shared across cluster, no per-node downloads
 - Proxmox 9 (Debian Trixie) needs Docker repo pinned to `bookworm`
 
+## GPU Passthrough
+- VFIO binds GPU for VM passthrough; `amdgpu` driver needed for LXC VAAPI transcoding — mutually exclusive per card
+- `nomodeset` in GRUB blocks `amdgpu` probe (error -22) — remove it if LXCs need GPU access
+- Proxmox installer leaves `/etc/default/grub.d/installer.cfg` with `nomodeset` — must remove, not just update `/etc/default/grub`
+- LXC GPU device passthrough uses `pct set --dev0 /dev/dri/card0,gid=44 --dev1 /dev/dri/renderD128,gid=993` — verify GIDs match host with `stat -c '%g' /dev/dri/*`
+- CephFS bind mounts (`mp0:`) block LXC HA migration — Proxmox refuses to migrate containers with bind mounts
+- Tailscale serve config is NOT persistent across LXC restarts — must re-run `tailscale serve` after container restart
+
+## Cloudflare
+- Zero Trust requires dashboard onboarding (team name) before Access API works — 403 until completed
+- Workers ES module format (`export default`) needs multipart upload — Ansible `uri` module can't do it, use `curl` via `command`
+- Access bypass policies don't support `ip_list` selector — use `allow` decision with `ip` selector instead
+- Cloudflare Workers KV free tier: 100k reads/day, 1k writes/day — throttle writes (e.g., 1/day per IP)
+- Access policy precedences must be unique — check existing policies before creating
+- `ansible.builtin.uri` runs in check mode by default (unlike `command`) — guard mutating API calls with `not ansible_check_mode`
+
 ## Hugo
 - Build: `cd site && hugo --minify`
 - Hugo is installed via Homebrew

--- a/ansible/roles/cloudflare_ip_registration/files/worker.js
+++ b/ansible/roles/cloudflare_ip_registration/files/worker.js
@@ -47,9 +47,15 @@ async function refreshActiveIps(env) {
     }
   );
 
-  if (!res.ok) return;
+  if (!res.ok) {
+    console.log(`refreshActiveIps: API returned ${res.status}`);
+    return;
+  }
   const data = await res.json();
-  if (!data.success || !data.result) return;
+  if (!data.success || !data.result || data.result.length === 0) {
+    console.log("refreshActiveIps: no audit log entries returned");
+    return;
+  }
 
   // Collect unique IPs that accessed Jellyfin
   const activeIps = new Set();

--- a/ansible/roles/cloudflare_ip_registration/files/worker.js
+++ b/ansible/roles/cloudflare_ip_registration/files/worker.js
@@ -30,10 +30,44 @@ export default {
   },
 
   async scheduled(event, env) {
-    // Cron: rebuild policy from surviving KV entries (expired ones auto-deleted)
+    // Refresh TTLs for IPs that actively accessed Jellyfin in the last 24h
+    await refreshActiveIps(env);
+    // Rebuild policy from surviving KV entries (expired ones auto-deleted)
     await rebuildPolicy(env);
   }
 };
+
+async function refreshActiveIps(env) {
+  // Query Access audit logs for media.8devops.com requests in the last 24h
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${env.ACCOUNT_ID}/access/logs/access_requests?direction=desc&limit=1000&since=${since}`,
+    {
+      headers: { Authorization: `Bearer ${env.CF_API_TOKEN}` }
+    }
+  );
+
+  if (!res.ok) return;
+  const data = await res.json();
+  if (!data.success || !data.result) return;
+
+  // Collect unique IPs that accessed Jellyfin
+  const activeIps = new Set();
+  for (const entry of data.result) {
+    if (entry.ip_address) {
+      activeIps.add(entry.ip_address);
+    }
+  }
+
+  // Refresh TTL for any registered IP that was active
+  const keys = await env.IP_KV.list({ prefix: "ip:" });
+  for (const key of keys.keys) {
+    const registeredIp = await env.IP_KV.get(key.name);
+    if (registeredIp && activeIps.has(registeredIp)) {
+      await env.IP_KV.put(key.name, registeredIp, { expirationTtl: TTL_SECONDS });
+    }
+  }
+}
 
 async function rebuildPolicy(env) {
   // Read all surviving KV entries

--- a/ansible/roles/cloudflare_ip_registration/files/worker.js
+++ b/ansible/roles/cloudflare_ip_registration/files/worker.js
@@ -41,7 +41,7 @@ async function refreshActiveIps(env) {
   // Query Access audit logs for media.8devops.com requests in the last 24h
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const res = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.ACCOUNT_ID}/access/logs/access_requests?direction=desc&limit=1000&since=${since}`,
+    `https://api.cloudflare.com/client/v4/accounts/${env.ACCOUNT_ID}/access/logs/access_requests?direction=desc&limit=1000&since=${since}&app_uid=${env.MEDIA_APP_ID}`,
     {
       headers: { Authorization: `Bearer ${env.CF_API_TOKEN}` }
     }

--- a/ansible/roles/cloudflare_ip_registration/tasks/main.yml
+++ b/ansible/roles/cloudflare_ip_registration/tasks/main.yml
@@ -155,7 +155,7 @@
   when: not ansible_check_mode
 
 # Set Worker secrets via secrets API
-- name: Set Worker secret {{ item.name }}
+- name: Set Worker secrets
   ansible.builtin.uri:
     url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/workers/scripts/{{ cloudflare_ip_reg_worker_name }}/secrets"
     method: PUT


### PR DESCRIPTION
## Summary
- Scheduled Worker queries Access audit logs daily for active Jellyfin IPs
- Refreshes KV TTL on active IPs (45 days from last activity)
- Inactive IPs still expire naturally
- Fix task name template warning on secret setting task

## Test plan
- [x] Worker deployed and running
- [x] ansible-lint passes
- [ ] CI passes
- [ ] Verify TTL refresh after 24h (manual check of KV entries)