### PR TITLE
Auto-redirect to Jellyfin after IP registration

### DIFF
--- a/ansible/roles/cloudflare_ip_registration/files/worker.js
+++ b/ansible/roles/cloudflare_ip_registration/files/worker.js
@@ -158,7 +158,7 @@ function htmlResponse(status, ip, email, state, ttlDays, registeredIp) {
     <div class="email">${email}</div>
     <div class="status ${state === "registered" ? "success" : ""}">${message}</div>
     ${showButton ? '<form method="POST"><button type="submit">Register My IP</button></form>' : ''}
-    ${state === "registered" ? '<div class="redirect"><a href="https://media.8devops.com">Go to Jellyfin</a></div>' : ''}
+    ${state === "registered" ? '<div class="redirect">Redirecting to <a href="https://media.8devops.com">Jellyfin</a>...</div><script>setTimeout(function(){window.location.href="https://media.8devops.com"},2000)</script>' : ''}
   </div>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- After tapping Register, page auto-redirects to media.8devops.com after 2 seconds
- Shows "Redirecting to Jellyfin..." confirmation text before redirect

## Test plan
- [x] Worker deployed
- [ ] CI passes