### PR TITLE
Add backup_client role to site.yml

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -57,6 +57,14 @@
   roles:
     - jellyfin_backup
 
+- name: Configure restic backup clients
+  hosts: backup_clients
+  become: true
+  vars_files:
+    - vault.yml
+  roles:
+    - backup_client
+
 - name: Setup DNS servers
   hosts: dns_servers
   become: true


### PR DESCRIPTION
## Summary
- The `backup_client` role (restic to pi-burg) was only applied via standalone `backup-setup.yml`
- Restic cron entry was lost on every LXC migration because `site.yml` never re-applied it
- This caused recurring backup gaps (March 8-April 1, April 3-17)

## Changes
- Add `backup_client` play to `site.yml` targeting `backup_clients` inventory group

## Test plan
- [ ] CI passes (lint + infra check)
- [ ] After merge, run playbook against jellyfin01 and verify restic cron is present