### PR TITLE
Fix cron startup in LXC and improve backup error handling

### DIFF
--- a/ansible/roles/backup_client/handlers/main.yml
+++ b/ansible/roles/backup_client/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload systemd and restart cron
+  ansible.builtin.systemd:
+    name: cron
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/backup_client/tasks/restic.yml
+++ b/ansible/roles/backup_client/tasks/restic.yml
@@ -40,6 +40,42 @@
     mode: "0755"
   no_log: true
 
+- name: Copy cron service unit without remote-fs dependency
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/cron.service
+    content: |
+      [Unit]
+      Description=Regular background program processing daemon
+      Documentation=man:cron(8)
+      After=nss-user-lookup.target
+
+      [Service]
+      EnvironmentFile=-/etc/default/cron
+      ExecStart=/usr/sbin/cron -f -P $EXTRA_OPTS
+      IgnoreSIGPIPE=false
+      KillMode=process
+      Restart=on-failure
+      SyslogFacility=cron
+
+      [Install]
+      WantedBy=multi-user.target
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd and restart cron
+
+- name: Remove stale cron override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/cron.service.d
+    state: absent
+  notify: Reload systemd and restart cron
+
+- name: Ensure cron is running
+  ansible.builtin.systemd:
+    name: cron
+    state: started
+    enabled: true
+
 - name: Setup backup cron job
   ansible.builtin.cron:
     name: "Restic backup to Pi"

--- a/ansible/roles/backup_client/templates/backup.sh.j2
+++ b/ansible/roles/backup_client/templates/backup.sh.j2
@@ -48,6 +48,7 @@ fi
 
 # Run backup
 log_message "Backing up: {{ backup_paths | join(', ') }}"
+BACKUP_STDERR=$(mktemp)
 BACKUP_OUTPUT=$(restic backup \
 {% for path in backup_paths %}
     "{{ path }}" \
@@ -55,7 +56,7 @@ BACKUP_OUTPUT=$(restic backup \
 {% for exclude in backup_excludes %}
     --exclude "{{ exclude }}" \
 {% endfor %}
-    --json 2>&1) && BACKUP_RC=0 || BACKUP_RC=$?
+    --json 2>"$BACKUP_STDERR") && BACKUP_RC=0 || BACKUP_RC=$?
 echo "$BACKUP_OUTPUT" >> "$LOGFILE"
 
 if [ $BACKUP_RC -eq 0 ]; then
@@ -70,12 +71,17 @@ if [ $BACKUP_RC -eq 0 ]; then
         DATA_ADDED=$(numfmt --to=iec --suffix=B "${BYTES_ADDED:-0}" 2>/dev/null || echo "${BYTES_ADDED:-0} bytes")
     fi
 else
+    BACKUP_ERROR=$(tail -5 "$BACKUP_STDERR")
     log_message "Backup failed with exit code $BACKUP_RC"
+    log_message "Error: $BACKUP_ERROR"
 {% if backup_notify_enabled | default(false) %}
-    notify "Backup FAILED on $(hostname)" "restic backup exited with code $BACKUP_RC at $(date)"
+    notify "Backup FAILED on $(hostname)" "restic backup exited with code $BACKUP_RC at $(date)
+Error: $BACKUP_ERROR"
 {% endif %}
+    rm -f "$BACKUP_STDERR"
     exit $BACKUP_RC
 fi
+rm -f "$BACKUP_STDERR"
 
 # Run retention policy
 log_message "Applying retention policy"


### PR DESCRIPTION
## Summary
- Override cron systemd unit to remove `remote-fs.target` dependency that never activates in LXC containers, preventing cron from starting after reboot
- Capture restic stderr separately so backup failures log the actual error message instead of just an exit code
- Include error details in Apprise failure notifications

## Test plan
- [x] Deployed to jellyfin01, cron survives reboot
- [x] Verified backup runs successfully after fixing pi-burg repo permissions
- [ ] Confirm backup cron fires tonight at 2am