### PR TITLE
Manage AdGuard DNS rewrites in Ansible

### DIFF
--- a/ansible/inventory/group_vars/dns_servers.yml
+++ b/ansible/inventory/group_vars/dns_servers.yml
@@ -9,6 +9,15 @@ tailscale_advertise_routes:
   - "10.150.70.0/24"
 
 adguard_home_tailscale_service: "svc:dns"
-adguard_home_conditional_forwards:
-  - domain: "taile975f.ts.net"
-    upstream: "100.100.100.100"
+
+# Conditional forwarders intentionally empty: forwarding *.ts.net to MagicDNS
+# defeats AdGuard's authority for LAN-resident hosts and forces traffic through
+# the Tailscale subnet router at MTU 1280. See feedback_tailscale_magicdns_lan.md.
+adguard_home_conditional_forwards: []
+
+# LAN-resident hosts that should resolve to LAN IPs even via Tailscale FQDN.
+adguard_home_rewrites:
+  - domain: jellyfin01
+    answer: 10.150.70.12
+  - domain: jellyfin01.taile975f.ts.net
+    answer: 10.150.70.12

--- a/ansible/roles/adguard_home/defaults/main.yml
+++ b/ansible/roles/adguard_home/defaults/main.yml
@@ -19,5 +19,8 @@ adguard_home_web_port: 3000
 # Conditional forwarding (list of {domain, upstream})
 adguard_home_conditional_forwards: []
 
+# DNS rewrites (list of {domain, answer}); reconciled on every run
+adguard_home_rewrites: []
+
 # Tailscale Service (empty string = disabled)
 adguard_home_tailscale_service: ""

--- a/ansible/roles/adguard_home/files/manage_rewrites.py
+++ b/ansible/roles/adguard_home/files/manage_rewrites.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Reconcile AdGuard Home DNS rewrites with the desired list passed via stdin.
+
+Stdin: JSON list of {"domain": str, "answer": str} objects (the desired state).
+Reads/writes /opt/AdGuardHome/AdGuardHome.yaml in place.
+Prints "CHANGED" if the file was modified, "OK" otherwise.
+Exit non-zero on error.
+"""
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path("/opt/AdGuardHome/AdGuardHome.yaml")
+
+
+def main() -> int:
+    desired = json.load(sys.stdin)
+    desired_normalized = sorted(
+        [{"domain": r["domain"], "answer": r["answer"], "enabled": True} for r in desired],
+        key=lambda r: (r["domain"], r["answer"]),
+    )
+
+    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    filtering = cfg.setdefault("filtering", {})
+    current = filtering.get("rewrites") or []
+    current_normalized = sorted(
+        [
+            {"domain": r["domain"], "answer": r["answer"], "enabled": r.get("enabled", True)}
+            for r in current
+        ],
+        key=lambda r: (r["domain"], r["answer"]),
+    )
+
+    if current_normalized == desired_normalized:
+        print("OK")
+        return 0
+
+    filtering["rewrites"] = desired_normalized
+    CONFIG_PATH.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False))
+    print("CHANGED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/roles/adguard_home/tasks/configure.yml
+++ b/ansible/roles/adguard_home/tasks/configure.yml
@@ -13,3 +13,24 @@
     mode: "0600"
   when: not adguard_home_config.stat.exists
   notify: Restart AdGuard Home
+
+- name: Ensure PyYAML available for rewrite reconciliation
+  ansible.builtin.package:
+    name: python3-yaml
+    state: present
+
+- name: Install rewrite reconciliation helper
+  ansible.builtin.copy:
+    src: manage_rewrites.py
+    dest: /opt/AdGuardHome/manage_rewrites.py
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Reconcile AdGuard Home DNS rewrites
+  ansible.builtin.command: /opt/AdGuardHome/manage_rewrites.py
+  args:
+    stdin: "{{ adguard_home_rewrites | to_json }}"
+  register: rewrite_result
+  changed_when: rewrite_result.stdout == "CHANGED"
+  notify: Restart AdGuard Home

--- a/ansible/roles/adguard_home/tasks/install.yml
+++ b/ansible/roles/adguard_home/tasks/install.yml
@@ -29,4 +29,3 @@
   ansible.builtin.command: /opt/AdGuardHome/AdGuardHome -s install
   args:
     creates: /etc/systemd/system/AdGuardHome.service
-  changed_when: true

--- a/ansible/roles/adguard_home/templates/AdGuardHome.yaml.j2
+++ b/ansible/roles/adguard_home/templates/AdGuardHome.yaml.j2
@@ -27,6 +27,13 @@ dns:
   cache_ttl_max: 0
   cache_optimistic: true
   upstream_mode: fastest_addr
+filtering:
+  rewrites:
+{% for r in adguard_home_rewrites %}
+    - domain: {{ r.domain }}
+      answer: {{ r.answer }}
+      enabled: true
+{% endfor %}
 filters:
   - enabled: true
     url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt


### PR DESCRIPTION
## Summary
- Adds `adguard_home_rewrites` role variable, reconciled idempotently on every run via small Python helper
- Removes the `*.taile975f.ts.net` conditional forwarder (was forcing LAN traffic through Tailscale subnet router at MTU 1280, ~50 Mbps vs 900+ Mbps direct)
- Declares jellyfin01 rewrites for both bare and Tailscale FQDN forms so split-DNS works regardless of search-domain expansion

## Test plan
- [x] ansible-lint passes
- [x] --check --diff shows expected changes only
- [x] Real run idempotent on second invocation (Reconcile task reports ok, not changed)
- [x] dig @10.150.60.11 jellyfin01 returns 10.150.70.12
- [x] dig @10.150.60.11 jellyfin01.taile975f.ts.net returns 10.150.70.12