### PR TITLE
Add second AdGuard (dns02) + Ansible-managed blocked services

### DIFF
--- a/ansible/inventory/group_vars/dns_servers.yml
+++ b/ansible/inventory/group_vars/dns_servers.yml
@@ -21,3 +21,46 @@ adguard_home_rewrites:
     answer: 10.150.70.12
   - domain: jellyfin01.taile975f.ts.net
     answer: 10.150.70.12
+
+# Service IDs blocked at DNS level (AdGuard's "Blocked services" presets).
+# Reconciled idempotently — order doesn't matter, duplicates ignored.
+adguard_home_blocked_services:
+  - 4chan
+  - 9gag
+  - aliexpress
+  - betano
+  - betfair
+  - betway
+  - blaze
+  - box
+  - clubhouse
+  - discord
+  - dropbox
+  - flickr
+  - imgur
+  - instagram
+  - kakaotalk
+  - kik
+  - line
+  - linkedin
+  - mail_ru
+  - mastodon
+  - max
+  - minecraft
+  - olvid
+  - onlyfans
+  - plenty_of_fish
+  - reddit
+  - shein
+  - signal
+  - skype
+  - snapchat
+  - telegram
+  - temu
+  - tinder
+  - viber
+  - wechat
+  - whatsapp
+  - wizz
+  - xiaohongshu
+  - youtube

--- a/ansible/inventory/homelab.yml
+++ b/ansible/inventory/homelab.yml
@@ -42,6 +42,9 @@ all:
       hosts:
         dns01:  # LXC 3002 on pve01, AdGuard Home + Tailscale subnet router
           ansible_user: root
+        dns02:  # LXC 3012 on pve03, AdGuard Home secondary (HA pair with dns01)
+          ansible_user: root
+          ansible_host: 10.150.60.12
 
     # mem0 Servers (VLAN 70, AI memory stack)
     mem0_servers:

--- a/ansible/roles/adguard_home/defaults/main.yml
+++ b/ansible/roles/adguard_home/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-adguard_home_version: "0.107.55"
+adguard_home_version: "0.107.74"
 adguard_home_arch: "linux_amd64"
 
 # DNS settings
@@ -21,6 +21,9 @@ adguard_home_conditional_forwards: []
 
 # DNS rewrites (list of {domain, answer}); reconciled on every run
 adguard_home_rewrites: []
+
+# Blocked services (list of AdGuard service IDs, e.g. "youtube"); reconciled on every run
+adguard_home_blocked_services: []
 
 # Tailscale Service (empty string = disabled)
 adguard_home_tailscale_service: ""

--- a/ansible/roles/adguard_home/files/manage_blocked_services.py
+++ b/ansible/roles/adguard_home/files/manage_blocked_services.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Reconcile AdGuard Home blocked-services list with the desired list passed via stdin.
+
+Stdin: JSON list of service ID strings (e.g. ["youtube", "tiktok"]).
+Reads/writes /opt/AdGuardHome/AdGuardHome.yaml in place.
+Prints "CHANGED" if the file was modified, "OK" otherwise.
+Exit non-zero on error.
+"""
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path("/opt/AdGuardHome/AdGuardHome.yaml")
+
+
+def main() -> int:
+    desired = sorted(set(json.load(sys.stdin)))
+
+    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    filtering = cfg.setdefault("filtering", {})
+    blocked = filtering.setdefault("blocked_services", {})
+    blocked.setdefault("schedule", {"time_zone": "Local"})
+    current = sorted(set(blocked.get("ids") or []))
+
+    if current == desired:
+        print("OK")
+        return 0
+
+    blocked["ids"] = desired
+    CONFIG_PATH.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False))
+    print("CHANGED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/roles/adguard_home/tasks/configure.yml
+++ b/ansible/roles/adguard_home/tasks/configure.yml
@@ -14,18 +14,21 @@
   when: not adguard_home_config.stat.exists
   notify: Restart AdGuard Home
 
-- name: Ensure PyYAML available for rewrite reconciliation
+- name: Ensure PyYAML available for filtering reconciliation
   ansible.builtin.package:
     name: python3-yaml
     state: present
 
-- name: Install rewrite reconciliation helper
+- name: Install filtering reconciliation helpers
   ansible.builtin.copy:
-    src: manage_rewrites.py
-    dest: /opt/AdGuardHome/manage_rewrites.py
+    src: "{{ item }}"
+    dest: "/opt/AdGuardHome/{{ item }}"
     owner: root
     group: root
     mode: "0755"
+  loop:
+    - manage_rewrites.py
+    - manage_blocked_services.py
 
 - name: Reconcile AdGuard Home DNS rewrites
   ansible.builtin.command: /opt/AdGuardHome/manage_rewrites.py
@@ -33,4 +36,12 @@
     stdin: "{{ adguard_home_rewrites | to_json }}"
   register: rewrite_result
   changed_when: rewrite_result.stdout == "CHANGED"
+  notify: Restart AdGuard Home
+
+- name: Reconcile AdGuard Home blocked services
+  ansible.builtin.command: /opt/AdGuardHome/manage_blocked_services.py
+  args:
+    stdin: "{{ adguard_home_blocked_services | to_json }}"
+  register: blocked_services_result
+  changed_when: blocked_services_result.stdout == "CHANGED"
   notify: Restart AdGuard Home

--- a/ansible/roles/adguard_home/tasks/install.yml
+++ b/ansible/roles/adguard_home/tasks/install.yml
@@ -6,24 +6,38 @@
     state: stopped
   failed_when: false
 
-- name: Check if AdGuard Home is already installed
-  ansible.builtin.stat:
-    path: /opt/AdGuardHome/AdGuardHome
-  register: adguard_home_binary
+- name: Check installed AdGuard Home version
+  ansible.builtin.command: /opt/AdGuardHome/AdGuardHome --version
+  register: adguard_home_installed_version
+  changed_when: false
+  failed_when: false
+
+- name: Set fact for whether install/upgrade is needed
+  ansible.builtin.set_fact:
+    adguard_home_needs_install: "{{ adguard_home_installed_version.rc != 0 or adguard_home_version not in adguard_home_installed_version.stdout }}"
 
 - name: Download AdGuard Home
   ansible.builtin.get_url:
     url: "https://github.com/AdguardTeam/AdGuardHome/releases/download/v{{ adguard_home_version }}/AdGuardHome_{{ adguard_home_arch }}.tar.gz"
-    dest: /tmp/AdGuardHome.tar.gz
+    dest: "/tmp/AdGuardHome-{{ adguard_home_version }}.tar.gz"
     mode: "0644"
-  when: not adguard_home_binary.stat.exists
+  when: adguard_home_needs_install
+
+- name: Stop AdGuard Home before upgrade in place
+  ansible.builtin.systemd:
+    name: AdGuardHome
+    state: stopped
+  when:
+    - adguard_home_needs_install
+    - adguard_home_installed_version.rc == 0
 
 - name: Extract AdGuard Home
   ansible.builtin.unarchive:
-    src: /tmp/AdGuardHome.tar.gz
+    src: "/tmp/AdGuardHome-{{ adguard_home_version }}.tar.gz"
     dest: /opt
     remote_src: true
-  when: not adguard_home_binary.stat.exists
+  when: adguard_home_needs_install
+  notify: Restart AdGuard Home
 
 - name: Install AdGuard Home systemd service
   ansible.builtin.command: /opt/AdGuardHome/AdGuardHome -s install

--- a/ansible/roles/adguard_home/tasks/service.yml
+++ b/ansible/roles/adguard_home/tasks/service.yml
@@ -10,6 +10,9 @@
   register: adguard_home_ports
   changed_when: false
   check_mode: false
+  until: "':53 ' in adguard_home_ports.stdout"
+  retries: 10
+  delay: 2
   failed_when: "':53 ' not in adguard_home_ports.stdout"
 
 - name: Check if Tailscale Service is already registered

--- a/ansible/roles/adguard_home/templates/AdGuardHome.yaml.j2
+++ b/ansible/roles/adguard_home/templates/AdGuardHome.yaml.j2
@@ -34,6 +34,13 @@ filtering:
       answer: {{ r.answer }}
       enabled: true
 {% endfor %}
+  blocked_services:
+    schedule:
+      time_zone: Local
+    ids:
+{% for s in adguard_home_blocked_services %}
+      - {{ s }}
+{% endfor %}
 filters:
   - enabled: true
     url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt


### PR DESCRIPTION
## Summary
Brings up dns02 on pve03 as an HA pair to dns01 and extends the `adguard_home` role so both can be reconciled identically.

### Role
- New `adguard_home_blocked_services` variable + `manage_blocked_services.py` reconciliation helper (parallel pattern to `manage_rewrites.py` from #416).
- Bumped pinned version `0.107.55 → 0.107.74` to match what dns01 had auto-updated to.
- `install.yml` now compares installed binary version against the pinned target and re-downloads on mismatch (was previously install-once-only).
- Tarball cache path now includes version (`/tmp/AdGuardHome-{version}.tar.gz`) so version bumps actually fetch the new artifact.
- `service.yml` verify task gets a 10×2s retry loop to absorb AdGuard's startup delay before port 53 binds.

### Inventory
- `dns02` added to `dns_servers` group at `10.150.60.12`.
- 39 blocked services declared in `dns_servers.yml` group_vars (mirrors what dns01 had configured via the UI).

## Test plan
- [x] ansible-lint passes
- [x] Playbook upgrades dns02 binary 0.107.55 → 0.107.74 (version-mismatch path works)
- [x] dns02 binds port 53 + accepts the "max" service ID (only present in 0.107.74+)
- [x] `dig @10.150.60.12 youtube.com +short` returns `0.0.0.0`
- [x] `dig @10.150.60.12 jellyfin01 +short` returns `10.150.70.12`
- [ ] Re-run is idempotent (`changed=0` on second invocation)

## Related cluster-side work (not in this PR)
- HA anti-affinity rule `dns-separate` (resource-affinity, negative) keeps ct:3002 + ct:3012 on different nodes
- EdgeRouter DHCP scopes need updating to advertise both `10.150.60.11` and `10.150.60.12` as DNS servers