### PR TITLE
Configure LVM thin pool autoextend on Proxmox hosts

### DIFF
--- a/ansible/roles/adguard_home/tasks/install.yml
+++ b/ansible/roles/adguard_home/tasks/install.yml
@@ -11,6 +11,7 @@
   register: adguard_home_installed_version
   changed_when: false
   failed_when: false
+  check_mode: false
 
 - name: Set fact for whether install/upgrade is needed
   ansible.builtin.set_fact:

--- a/ansible/roles/proxmox/defaults/main.yml
+++ b/ansible/roles/proxmox/defaults/main.yml
@@ -24,3 +24,7 @@ proxmox_gpu_passthrough_enabled: false
 proxmox_gpu_vfio_ids: ""
 proxmox_gpu_blacklist_drivers: []
 proxmox_gpu_grub_extra: ""
+
+# LVM thin pool autoextend (#378)
+proxmox_lvm_thin_autoextend_threshold: 80
+proxmox_lvm_thin_autoextend_percent: 20

--- a/ansible/roles/proxmox/tasks/lvm.yml
+++ b/ansible/roles/proxmox/tasks/lvm.yml
@@ -1,0 +1,18 @@
+---
+- name: Configure LVM thin pool autoextend threshold
+  ansible.builtin.lineinfile:
+    path: /etc/lvm/lvm.conf
+    regexp: '^[\s#]*thin_pool_autoextend_threshold\s*='
+    line: "	thin_pool_autoextend_threshold = {{ proxmox_lvm_thin_autoextend_threshold }}"
+    insertafter: '^activation\s*{'
+    state: present
+    backup: true
+
+- name: Configure LVM thin pool autoextend percent
+  ansible.builtin.lineinfile:
+    path: /etc/lvm/lvm.conf
+    regexp: '^[\s#]*thin_pool_autoextend_percent\s*='
+    line: "	thin_pool_autoextend_percent = {{ proxmox_lvm_thin_autoextend_percent }}"
+    insertafter: '^activation\s*{'
+    state: present
+    backup: true

--- a/ansible/roles/proxmox/tasks/main.yml
+++ b/ansible/roles/proxmox/tasks/main.yml
@@ -8,3 +8,5 @@
 - name: Configure GPU passthrough
   ansible.builtin.include_tasks: gpu-passthrough.yml
   when: proxmox_gpu_passthrough_enabled | default(false)
+- name: Configure LVM thin pool autoextend
+  ansible.builtin.include_tasks: lvm.yml


### PR DESCRIPTION
## Summary
- Adds `roles/proxmox/tasks/lvm.yml` to set `thin_pool_autoextend_threshold = 80` and `thin_pool_autoextend_percent = 20` in `/etc/lvm/lvm.conf`
- Wires it into the proxmox role main task list and adds defaults so values are tunable
- **Bundled fix**: adds `check_mode: false` to the AdGuard version check task so CI's `--check --diff` no longer fails on the subsequent extract step (recurring check_mode pattern, this is the 4th hit)
- Closes #378

## Why
Stock lvm.conf has thin pool autoextend disabled (threshold=100). When `nvme-local` fills, LVM stops accepting writes from any VM/LXC using it — guests see I/O errors. Proxmox warns about this during migrations (seen on pve03 during dns01 and mem01 migrations 2026-04-14). Threshold 80 / percent 20 is the standard Proxmox-recommended config: when the pool hits 80% used, grow it by 20% from free VG space.

## Implementation notes
- Uses `lineinfile` with regex matching the commented stock entries; falls back to `insertafter: '^activation\s*{'` if not found
- `backup: true` on each edit — original lvm.conf preserved as `/etc/lvm/lvm.conf.YYYY-MM-DD@HH:MM:SS~` on each host
- Defaults exposed so per-host tuning is possible if needed (`proxmox_lvm_thin_autoextend_threshold` / `proxmox_lvm_thin_autoextend_percent`)
- Applies to all hosts in the `proxmox` parent group (legacy + new clusters); harmless on legacy
- AdGuard fix is one line: command tasks need `check_mode: false` when downstream logic depends on the registered output

## Test plan
- [ ] CI `--check --diff` shows expected lvm.conf changes on pve01-03 (and harmlessly on legacy)
- [ ] CI `Test Against Infrastructure` passes (was failing on AdGuard, now fixed)
- [ ] ansible-lint clean (verified locally for both roles)
- [ ] After merge: stage rollout pve03 → pve02 → pve01, verify `lvm.conf` parses with `lvm dumpconfig activation/thin_pool_autoextend_threshold` on each
- [ ] Confirm warning no longer appears during next LXC migration

## Risk
Low. Worst realistic case is a malformed lvm.conf preventing LVM activation on next boot — backup file is left on disk for quick rollback. Recommend staging the apply one host at a time after merge.