### PR TITLE
Fix Apprise URL quoting and cloudflare changed_when leftover

### DIFF
--- a/ansible/roles/backup_client/templates/apprise.yml.j2
+++ b/ansible/roles/backup_client/templates/apprise.yml.j2
@@ -1,4 +1,4 @@
 # Apprise config — managed by Ansible. Mode 0600 root:root.
 # Kept out of the backup script so the credential is not world-readable.
 urls:
-  - {{ backup_apprise_urls }}
+  - "{{ backup_apprise_urls }}"

--- a/ansible/roles/cloudflare_ip_registration/tasks/main.yml
+++ b/ansible/roles/cloudflare_ip_registration/tasks/main.yml
@@ -327,6 +327,7 @@
     return_content: true
     status_code: [200, 201]
   no_log: true
+  changed_when: false
   when:
     - reg_app_check.json.result | length > 0
     - not ansible_check_mode


### PR DESCRIPTION
Replaces #431, which became unmergeable after the #430 squash merge rewrote its shared history (2-line delta recreated on a fresh branch off main).

- Quote the Apprise URL in `apprise.yml.j2` so credentials containing YAML special characters parse correctly
- Add `changed_when: false` to the Cloudflare Access policy lookup task since it only reads state