### PR TITLE
Remove minecraft from AdGuard blocked services

### DIFF
--- a/ansible/inventory/group_vars/dns_servers.yml
+++ b/ansible/inventory/group_vars/dns_servers.yml
@@ -47,7 +47,6 @@ adguard_home_blocked_services:
   - mail_ru
   - mastodon
   - max
-  - minecraft
   - olvid
   - onlyfans
   - plenty_of_fish


### PR DESCRIPTION
Removes `minecraft` from `adguard_home_blocked_services` on the DNS servers so Minecraft traffic is no longer blocked by AdGuard Home.