### PR TITLE
Add Proxmox services dashboard

### DIFF
--- a/.github/workflows/validate-services-data.yml
+++ b/.github/workflows/validate-services-data.yml
@@ -2,6 +2,9 @@ name: Validate services data
 
 on:
   pull_request:
+    paths:
+      - 'site/data/services.yml'
+      - 'scripts/validate-services.py'
   push:
     paths:
       - 'site/data/services.yml'
@@ -17,6 +20,6 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: python -m pip install pyyaml
+        run: python3 -m pip install pyyaml
       - name: Run services data validator
         run: python3 scripts/validate-services.py

--- a/.github/workflows/validate-services-data.yml
+++ b/.github/workflows/validate-services-data.yml
@@ -1,0 +1,22 @@
+name: Validate services data
+
+on:
+  pull_request:
+  push:
+    paths:
+      - 'site/data/services.yml'
+      - 'scripts/validate-services.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: python -m pip install pyyaml
+      - name: Run services data validator
+        run: python3 scripts/validate-services.py

--- a/scripts/validate-services.py
+++ b/scripts/validate-services.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import sys
+import yaml
+from pathlib import Path
+
+p = Path('site/data/services.yml')
+if not p.exists():
+    print('site/data/services.yml not found', file=sys.stderr)
+    sys.exit(1)
+
+data = yaml.safe_load(p.read_text())
+errors = []
+
+def check_url(name, url, ctx):
+    if url is None:
+        return
+    if not isinstance(url, str):
+        errors.append(f'{ctx}: {name} is not a string')
+        return
+    if not (url.startswith('http://') or url.startswith('https://')):
+        errors.append(f'{ctx}: {name} has non-http(s) URL: {url}')
+
+# nodes
+nodes = data.get('nodes', [])
+if not isinstance(nodes, list):
+    errors.append('nodes must be a list')
+else:
+    for i, node in enumerate(nodes):
+        ctx = f'nodes[{i}]'
+        host = node.get('host')
+        if not host:
+            errors.append(f'{ctx}: missing host')
+        check_url('proxmox_url', node.get('proxmox_url'), ctx)
+        check_url('netdata_url', node.get('netdata_url'), ctx)
+        containers = node.get('containers', [])
+        if not isinstance(containers, list):
+            errors.append(f'{ctx}: containers must be a list')
+        else:
+            for j, c in enumerate(containers):
+                cctx = f'{ctx}.containers[{j}]'
+                vmid = c.get('vmid')
+                if not isinstance(vmid, int):
+                    errors.append(f'{cctx}: vmid must be an integer (got {type(vmid).__name__})')
+                if 'name' not in c:
+                    errors.append(f'{cctx}: missing name')
+                check_url('console', c.get('console'), cctx)
+
+# endpoints
+endpoints = data.get('endpoints', [])
+if not isinstance(endpoints, list):
+    errors.append('endpoints must be a list')
+else:
+    for k, e in enumerate(endpoints):
+        ectx = f'endpoints[{k}]'
+        check_url('url', e.get('url'), ectx)
+
+if errors:
+    print('Validation failed:')
+    for e in errors:
+        print('- ' + e)
+    sys.exit(2)
+
+print('Validation passed')
+sys.exit(0)

--- a/scripts/validate-services.py
+++ b/scripts/validate-services.py
@@ -8,7 +8,20 @@ if not p.exists():
     print('site/data/services.yml not found', file=sys.stderr)
     sys.exit(1)
 
-data = yaml.safe_load(p.read_text())
+try:
+    data = yaml.safe_load(p.read_text())
+except yaml.YAMLError as exc:
+    print(f'Failed to parse YAML: {exc}', file=sys.stderr)
+    sys.exit(2)
+
+if data is None:
+    print('site/data/services.yml is empty', file=sys.stderr)
+    sys.exit(2)
+
+if not isinstance(data, dict):
+    print('site/data/services.yml root must be a mapping/object', file=sys.stderr)
+    sys.exit(2)
+
 errors = []
 
 def check_url(name, url, ctx):

--- a/site/content/projects/proxmox-services-dashboard.md
+++ b/site/content/projects/proxmox-services-dashboard.md
@@ -1,0 +1,9 @@
+---
+title: "Proxmox Services Dashboard"
+date: 2026-08-13T21:53:00-05:00
+draft: false
+---
+
+{{< services-dashboard >}}
+
+<!-- Generated from site/data/services.yml; edit that file or update via Ansible probe -->

--- a/site/data/services.yml
+++ b/site/data/services.yml
@@ -1,0 +1,70 @@
+nodes:
+  - host: pve01
+    proxmox_url: "https://pve01:8006"
+    netdata_url: "http://pve01:19999"
+    tailscale: true
+    containers:
+      - vmid: 100
+        name: metube
+        status: running
+      - vmid: 3001
+        name: jellyfin01
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3001"
+      - vmid: 3002
+        name: dns01
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3002"
+      - vmid: 3007
+        name: changedetection
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3007"
+      - vmid: 3008
+        name: readeck
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3008"
+      - vmid: 3009
+        name: alpine-it-tools
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3009"
+      - vmid: 3010
+        name: docker
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3010"
+      - vmid: 3011
+        name: unifi
+        status: running
+        console: "https://pve01:8006/?console=lxc&vmid=3011"
+  - host: pve02
+    proxmox_url: "https://pve02:8006"
+    netdata_url: "http://pve02:19999"
+    tailscale: true
+    containers:
+      - vmid: 3006
+        name: mc03
+        status: stopped
+  - host: pve03
+    proxmox_url: "https://pve03:8006"
+    netdata_url: "http://pve03:19999"
+    tailscale: true
+    containers:
+      - vmid: 3004
+        name: mc01
+        status: stopped
+      - vmid: 3012
+        name: dns02
+        status: running
+        console: "https://pve03:8006/?console=lxc&vmid=3012"
+
+endpoints:
+  - name: Jellyfin (Cloudflare Tunnel)
+    url: "https://media.8devops.com"
+    target: "jellyfin01"
+  - name: Proxmox Cluster UI
+    url: "https://pve01:8006/"
+  - name: Netdata (cluster-level)
+    note: "Per-node Netdata URLs are listed under each host"
+
+notes:
+  - "This data file is generated from a quick repo + live probe. Update via Ansible or by editing this file."
+  - "For remote access use Cloudflare Tunnel or Tailscale addresses (see Cloudflare/Tailscale configs in ansible/)."

--- a/site/data/services.yml
+++ b/site/data/services.yml
@@ -67,4 +67,5 @@ endpoints:
 
 notes:
   - "This data file is generated from a quick repo + live probe. Update via Ansible or by editing this file."
+  - "Netdata entries may use http and are intended for internal access only; do not expose these URLs publicly without TLS/proxying."
   - "For remote access use Cloudflare Tunnel or Tailscale addresses (see Cloudflare/Tailscale configs in ansible/)."

--- a/site/layouts/shortcodes/services-dashboard.html
+++ b/site/layouts/shortcodes/services-dashboard.html
@@ -1,0 +1,40 @@
+{{/* services-dashboard shortcode: renders data/services.yml into HTML lists */}}
+{{ $d := site.Data.services }}
+<div class="services-dashboard">
+  <h2>Proxmox Hosts</h2>
+  <ul>
+  {{ range $d.nodes }}
+    <li>
+      <strong>{{ .host }}</strong> — <a href="{{ .proxmox_url }}">Proxmox UI</a>
+      {{ if .netdata_url }} — <a href="{{ .netdata_url }}">Netdata</a>{{ end }}
+      {{ if .tailscale }} — Tailscale: enabled{{ end }}
+      {{ if .containers }}
+        <ul>
+        {{ range .containers }}
+          <li>{{ .name }} (LXC {{ .vmid }}) — {{ .status }} {{ if .console }} — <a href="{{ .console }}">Console</a>{{ end }}</li>
+        {{ end }}
+        </ul>
+      {{ end }}
+    </li>
+  {{ end }}
+  </ul>
+
+  <h2>Endpoints</h2>
+  <ul>
+  {{ range $d.endpoints }}
+    <li>
+      {{ .name }} — <a href="{{ .url }}">{{ .url }}</a>
+      {{ if .target }} (targets: {{ .target }}){{ end }}
+    </li>
+  {{ end }}
+  </ul>
+
+  {{ if $d.notes }}
+  <h3>Notes</h3>
+  <ul>
+    {{ range $d.notes }}
+      <li>{{ . }}</li>
+    {{ end }}
+  </ul>
+  {{ end }}
+</div>

--- a/site/layouts/shortcodes/services-dashboard.html
+++ b/site/layouts/shortcodes/services-dashboard.html
@@ -5,13 +5,27 @@
   <ul>
   {{ range $d.nodes }}
     <li>
-      <strong>{{ .host }}</strong> — <a href="{{ .proxmox_url }}">Proxmox UI</a>
-      {{ if .netdata_url }} — <a href="{{ .netdata_url }}">Netdata</a>{{ end }}
+      <strong>{{ .host }}</strong> — 
+      {{ if and .proxmox_url (or (strings.HasPrefix .proxmox_url "https://") (strings.HasPrefix .proxmox_url "http://")) }}
+        <a href="{{ .proxmox_url }}" target="_blank" rel="noopener noreferrer">Proxmox UI</a>
+      {{ else }}
+        Proxmox UI
+      {{ end }}
+      {{ if and .netdata_url (or (strings.HasPrefix .netdata_url "https://") (strings.HasPrefix .netdata_url "http://")) }} — <a href="{{ .netdata_url }}" target="_blank" rel="noopener noreferrer">Netdata</a>{{ end }}
       {{ if .tailscale }} — Tailscale: enabled{{ end }}
       {{ if .containers }}
         <ul>
         {{ range .containers }}
-          <li>{{ .name }} (LXC {{ .vmid }}) — {{ .status }} {{ if .console }} — <a href="{{ .console }}">Console</a>{{ end }}</li>
+          <li>
+            {{ .name }} (LXC {{ .vmid }}) — {{ .status }}
+            {{ if .console }}
+              {{ if or (strings.HasPrefix .console "https://") (strings.HasPrefix .console "http://" ) }}
+                — <a href="{{ .console }}" target="_blank" rel="noopener noreferrer">Console</a>
+              {{ else }}
+                — Console
+              {{ end }}
+            {{ end }}
+          </li>
         {{ end }}
         </ul>
       {{ end }}
@@ -23,7 +37,12 @@
   <ul>
   {{ range $d.endpoints }}
     <li>
-      {{ .name }} — <a href="{{ .url }}">{{ .url }}</a>
+      {{ .name }} — 
+      {{ if and .url (or (strings.HasPrefix .url "https://") (strings.HasPrefix .url "http://")) }}
+        <a href="{{ .url }}" target="_blank" rel="noopener noreferrer">{{ .url }}</a>
+      {{ else }}
+        {{ .url }}
+      {{ end }}
       {{ if .target }} (targets: {{ .target }}){{ end }}
     </li>
   {{ end }}


### PR DESCRIPTION
Adds a data-driven Proxmox services dashboard (site/data/services.yml, shortcode, and page). Generated from a repo + live probe and rendered by a Hugo shortcode.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>