### PR TITLE
backup_client: move restic password out of backup scripts into a file

### DIFF
--- a/ansible/roles/backup_client/defaults/main.yml
+++ b/ansible/roles/backup_client/defaults/main.yml
@@ -37,6 +37,9 @@ backup_script_path: /usr/local/bin/backup-library.sh
 backup_check_script_path: /usr/local/bin/restic-check.sh
 backup_log_path: /var/log/restic-backup.log
 
+# Restic password file (kept out of the backup scripts themselves)
+backup_password_file: /etc/restic/password
+
 # Weekly check schedule (default: Sunday 6am)
 backup_check_cron_hour: "6"
 backup_check_cron_minute: "0"

--- a/ansible/roles/backup_client/tasks/restic.yml
+++ b/ansible/roles/backup_client/tasks/restic.yml
@@ -41,6 +41,23 @@
   no_log: true
   when: backup_notify_enabled | bool
 
+- name: Create restic config directory
+  ansible.builtin.file:
+    path: "{{ backup_password_file | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: Deploy restic password file
+  ansible.builtin.copy:
+    content: "{{ restic_password }}"
+    dest: "{{ backup_password_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
+
 - name: Deploy backup script
   ansible.builtin.template:
     src: backup.sh.j2
@@ -48,7 +65,6 @@
     owner: root
     group: root
     mode: "0755"
-  no_log: true
 
 - name: Copy cron service unit without remote-fs dependency
   ansible.builtin.copy:
@@ -102,7 +118,6 @@
     owner: root
     group: root
     mode: "0755"
-  no_log: true
 
 - name: Setup weekly restic check cron
   ansible.builtin.cron:

--- a/ansible/roles/backup_client/templates/backup.sh.j2
+++ b/ansible/roles/backup_client/templates/backup.sh.j2
@@ -10,10 +10,10 @@ export PATH="/usr/local/bin:$PATH"
 
 LOGFILE="{{ backup_log_path }}"
 RESTIC_REPOSITORY="sftp:{{ backup_server_user }}@{{ backup_server_host }}:{{ backup_server_repo_path }}"
-RESTIC_PASSWORD="{{ restic_password }}"
+RESTIC_PASSWORD_FILE="{{ backup_password_file }}"
 
 export RESTIC_REPOSITORY
-export RESTIC_PASSWORD
+export RESTIC_PASSWORD_FILE
 
 {% if backup_notify_enabled | default(false) %}
 # Apprise URLs are read from /etc/apprise.yml (mode 0600). The script itself

--- a/ansible/roles/backup_client/templates/restic-check.sh.j2
+++ b/ansible/roles/backup_client/templates/restic-check.sh.j2
@@ -10,10 +10,10 @@ export PATH="/usr/local/bin:$PATH"
 
 LOGFILE="{{ backup_log_path }}"
 RESTIC_REPOSITORY="sftp:{{ backup_server_user }}@{{ backup_server_host }}:{{ backup_server_repo_path }}"
-RESTIC_PASSWORD="{{ restic_password }}"
+RESTIC_PASSWORD_FILE="{{ backup_password_file }}"
 
 export RESTIC_REPOSITORY
-export RESTIC_PASSWORD
+export RESTIC_PASSWORD_FILE
 
 {% if backup_notify_enabled | default(false) %}
 # Apprise URLs are read from /etc/apprise.yml (mode 0600). The script itself


### PR DESCRIPTION
## Summary
- Deploys the restic password to `/etc/restic/password` (root, 0600) via a new `Deploy restic password file` task, using `backup_password_file` (default `/etc/restic/password`)
- `backup.sh.j2` and `restic-check.sh.j2` now export `RESTIC_PASSWORD_FILE` instead of embedding the plaintext password as `RESTIC_PASSWORD`
- Dropped `no_log: true` from the two script-deploy tasks since they no longer render the secret, so `--check --diff` output stays useful there; kept it on the new password-file task

Closes #354

## Test plan
- [x] `ansible-lint` on the changed role files — passed
- [ ] `ansible-playbook backup-setup.yml --check --diff` against a backup client (needs vault password — please run)
- [ ] Apply for real on a backup client, confirm `/etc/restic/password` is 0600 root-owned and the cron backup still runs successfully
- [ ] Confirm `restic-check.sh` still passes with `RESTIC_PASSWORD_FILE`