### PR TITLE
adguard_home: reconcile web/DNS bind settings on every run

### DIFF
--- a/ansible/roles/adguard_home/README.md
+++ b/ansible/roles/adguard_home/README.md
@@ -1,0 +1,33 @@
+# adguard_home
+
+Deploys and reconciles AdGuard Home.
+
+## Ansible-managed (reconciled on every run, drift is corrected)
+
+- Web UI bind address/port (`adguard_home_web_bind` / `adguard_home_web_port`)
+- DNS bind address/port (`adguard_home_dns_bind` / `adguard_home_dns_port`)
+- Users / admin password (`adguard_home_username` / `adguard_home_password`)
+- DNS rewrites (`adguard_home_rewrites`)
+- Blocked services (`adguard_home_blocked_services`)
+
+These are reconciled via the `manage_*.py` scripts in `files/`, which patch
+`/opt/AdGuardHome/AdGuardHome.yaml` in place rather than re-templating it, so
+fields not listed here are left alone.
+
+## Initial-deploy only (templated once, not reconciled after)
+
+- Upstream/bootstrap DNS (`adguard_home_upstream_dns`, `adguard_home_bootstrap_dns`)
+- Conditional forwards (`adguard_home_conditional_forwards`)
+
+These are only written when `AdGuardHome.yaml` doesn't exist yet. If AdGuard's
+setup wizard creates the file first, or someone edits these via the UI, a
+re-run of this role will not correct them.
+
+## UI-managed (not touched by Ansible at all)
+
+- Query log / stats retention settings
+- Custom filter lists added through the UI
+- Client-specific settings
+
+Anything in this list can be changed by hand and will survive a re-run of
+this role.

--- a/ansible/roles/adguard_home/files/manage_settings.py
+++ b/ansible/roles/adguard_home/files/manage_settings.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Reconcile AdGuard Home web/DNS bind settings with the desired state on stdin.
+
+Stdin: JSON object {"http_address": str, "dns_bind_hosts": [str], "dns_port": int}.
+Reads/writes /opt/AdGuardHome/AdGuardHome.yaml in place.
+Prints "CHANGED" if the file was modified, "OK" otherwise.
+Exit non-zero on error.
+"""
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path("/opt/AdGuardHome/AdGuardHome.yaml")
+
+
+def main() -> int:
+    desired = json.load(sys.stdin)
+
+    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    http = cfg.setdefault("http", {})
+    dns = cfg.setdefault("dns", {})
+
+    changed = False
+
+    if http.get("address") != desired["http_address"]:
+        http["address"] = desired["http_address"]
+        changed = True
+
+    if dns.get("bind_hosts") != desired["dns_bind_hosts"]:
+        dns["bind_hosts"] = desired["dns_bind_hosts"]
+        changed = True
+
+    if dns.get("port") != desired["dns_port"]:
+        dns["port"] = desired["dns_port"]
+        changed = True
+
+    if not changed:
+        print("OK")
+        return 0
+
+    CONFIG_PATH.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False))
+    print("CHANGED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/roles/adguard_home/tasks/configure.yml
+++ b/ansible/roles/adguard_home/tasks/configure.yml
@@ -32,6 +32,18 @@
     - manage_rewrites.py
     - manage_blocked_services.py
     - manage_users.py
+    - manage_settings.py
+
+- name: Reconcile AdGuard Home web/DNS bind settings
+  ansible.builtin.command: /opt/AdGuardHome/manage_settings.py
+  args:
+    stdin: >-
+      {{ {'http_address': adguard_home_web_bind ~ ':' ~ adguard_home_web_port,
+          'dns_bind_hosts': [adguard_home_dns_bind],
+          'dns_port': adguard_home_dns_port} | to_json }}
+  register: settings_result
+  changed_when: settings_result.stdout == "CHANGED"
+  notify: Restart AdGuard Home
 
 - name: Reconcile AdGuard Home DNS rewrites
   ansible.builtin.command: /opt/AdGuardHome/manage_rewrites.py


### PR DESCRIPTION
## Summary
- Adds `manage_settings.py`, following the existing `manage_rewrites.py`/`manage_blocked_services.py` pattern, to reconcile `http.address` and `dns.bind_hosts`/`dns.port` against role defaults on every run
- Wires it into `configure.yml` alongside the other reconciliation scripts
- Adds a role README documenting which fields are Ansible-managed (reconciled every run), initial-deploy-only (templated once, not corrected later — upstream/bootstrap DNS, conditional forwards), and UI-managed (left alone entirely)

Root cause per the issue: if AdGuard's setup wizard writes `AdGuardHome.yaml` before Ansible gets there (or the UI changes it), the role's `when: not adguard_home_config.stat.exists` guard meant web/DNS bind settings never converged — which is exactly what happened on dns02 (port 80 + apache2 collision).

Closes #425

## Test plan
- [x] `ansible-lint` on the changed/new files — passed
- [x] Simulated a drifted config locally (`http.address: 0.0.0.0:80`) and ran `manage_settings.py` directly — correctly reconciles to `0.0.0.0:3000`, `session_ttl: 720h` (Go duration string) survives the YAML round-trip untouched, and a second run reports `OK` (idempotent)
- [ ] `ansible-playbook site.yml --check --diff --limit dns01,dns02` (needs vault password — please run)
- [ ] Apply for real on dns01/dns02, confirm web UI/DNS ports match role defaults and AdGuard doesn't restart-loop